### PR TITLE
Feature/make request refresh token

### DIFF
--- a/app/LoginButton/index.js
+++ b/app/LoginButton/index.js
@@ -3,7 +3,7 @@
 // istanbul ignore file
 import React from 'react';
 import { Image, Text, TouchableOpacity, View } from 'react-native';
-import { login, getToken, getParameters } from 'sdk-gubuy-test';
+import { login, getToken, refreshToken, getParameters } from 'sdk-gubuy-test';
 
 import styles from './styles';
 import LogoAgesicSimple from './images/logoAgesicSimple.png';
@@ -15,6 +15,8 @@ const LoginButton = () => {
       console.log(`Code: ${code}`);
       const token = await getToken();
       console.log(`Token: ${token}`);
+      const newToken = await refreshToken();
+      console.log(`New Token: ${newToken}`);
       const parameters = getParameters();
       console.log(parameters);
     } catch (err) {

--- a/app/LoginButton/index.js
+++ b/app/LoginButton/index.js
@@ -3,7 +3,6 @@
 // istanbul ignore file
 import React from 'react';
 import { Image, Text, TouchableOpacity, View } from 'react-native';
-// eslint-disable-next-line import/no-unresolved
 import { login, getToken, refreshToken, getParameters } from 'sdk-gubuy-test';
 
 import styles from './styles';

--- a/app/LoginButton/index.js
+++ b/app/LoginButton/index.js
@@ -3,6 +3,7 @@
 // istanbul ignore file
 import React from 'react';
 import { Image, Text, TouchableOpacity, View } from 'react-native';
+// eslint-disable-next-line import/no-unresolved
 import { login, getToken, refreshToken, getParameters } from 'sdk-gubuy-test';
 
 import styles from './styles';

--- a/sdk/index.js
+++ b/sdk/index.js
@@ -1,5 +1,5 @@
 // istanbul ignore file
-import { initialize, login, getToken } from './interfaces';
+import { initialize, login, getToken, refreshToken } from './interfaces';
 import { getParameters } from './configuration';
 
-export { initialize, login, getToken, getParameters };
+export { initialize, login, getToken, getParameters, refreshToken };

--- a/sdk/interfaces/__tests__/getToken.test.js
+++ b/sdk/interfaces/__tests__/getToken.test.js
@@ -1,0 +1,30 @@
+import makeRequest from '../../requests';
+import { getToken } from '../index';
+import REQUEST_TYPES from '../../requests/constants';
+
+jest.mock('../../requests');
+
+afterEach(() => jest.clearAllMocks());
+
+describe('getToken', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls getToken correctly', async () => {
+    const token = 'c9747e3173544b7b870d48aeafa0f661';
+    makeRequest.mockReturnValue(Promise.resolve(token));
+    const response = await getToken();
+    expect(response).toBe(token);
+  });
+
+  it('calls getToken incorrectly', async () => {
+    makeRequest.mockReturnValue(Promise.reject(Error()));
+    try {
+      await getToken();
+    } catch (error) {
+      expect(error).toMatchObject(Error());
+    }
+    expect(makeRequest).toHaveBeenCalledTimes(1);
+    expect(makeRequest).toHaveBeenCalledWith(REQUEST_TYPES.GET_TOKEN);
+    expect.assertions(3);
+  });
+});

--- a/sdk/interfaces/__tests__/index.test.js
+++ b/sdk/interfaces/__tests__/index.test.js
@@ -1,77 +1,28 @@
-import { initialize, getToken, refreshToken } from '../index';
-import makeRequest from '../../requests';
+import { initialize } from '../index';
 import { getParameters } from '../../configuration';
 
 jest.mock('../../requests');
-const REQUEST_TYPES = jest.requireActual('../../requests/constants');
-const requestFailedMessage = "Couldn't make request";
+afterEach(() => jest.clearAllMocks());
 
 describe('initialize', () => {
-  const parameters = {
-    redirectUri: 'redirectUri',
-    clientId: 'clientId',
-    clientSecret: 'clientSecret',
-  };
-  initialize(
-    parameters.redirectUri,
-    parameters.clientId,
-    parameters.clientSecret,
-  );
-  const responseParameters = getParameters();
-  expect(responseParameters.redirectUri).toStrictEqual(parameters.redirectUri);
-  expect(responseParameters.clientId).toStrictEqual(parameters.clientId);
-  expect(responseParameters.clientSecret).toStrictEqual(
-    parameters.clientSecret,
-  );
-});
-
-describe('getToken', () => {
-  afterEach(() => jest.clearAllMocks());
-
-  it('calls getToken correctly', async () => {
-    const token = 'c9747e3173544b7b870d48aeafa0f661';
-    makeRequest.mockReturnValue(Promise.resolve(token));
-    const response = await getToken();
-    expect(response).toBe(token);
-  });
-
-  it('calls getToken incorrectly', async () => {
-    makeRequest.mockReturnValue(Promise.reject(Error()));
-    try {
-      await getToken();
-    } catch (error) {
-      expect(error).toMatchObject(Error());
-    }
-    expect(makeRequest).toHaveBeenCalledTimes(1);
-    expect(makeRequest).toHaveBeenCalledWith(REQUEST_TYPES.GET_TOKEN);
-    expect.assertions(3);
-  });
-});
-
-describe('refreshToken', () => {
-  afterEach(() => jest.clearAllMocks());
-
-  it('calls refreshToken correctly', async () => {
-    const newToken = '041a156232ac43c6b719c57b7217c9ee';
-    makeRequest.mockReturnValue(Promise.resolve(newToken));
-
-    const response = await refreshToken();
-
-    expect(response).toBe(newToken);
-  });
-
-  it('calls refreshToken incorrectly', async () => {
-    makeRequest.mockReturnValue(
-      Promise.reject(new Error(requestFailedMessage)),
+  it('works correctly', () => {
+    const parameters = {
+      redirectUri: 'redirectUri',
+      clientId: 'clientId',
+      clientSecret: 'clientSecret',
+    };
+    initialize(
+      parameters.redirectUri,
+      parameters.clientId,
+      parameters.clientSecret,
     );
-    try {
-      await refreshToken();
-    } catch (error) {
-      expect(error).toMatchObject(Error(requestFailedMessage));
-    }
-
-    expect(makeRequest).toHaveBeenCalledTimes(1);
-    expect(makeRequest).toHaveBeenCalledWith(REQUEST_TYPES.GET_REFRESH_TOKEN);
-    expect.assertions(3);
+    const responseParameters = getParameters();
+    expect(responseParameters.redirectUri).toStrictEqual(
+      parameters.redirectUri,
+    );
+    expect(responseParameters.clientId).toStrictEqual(parameters.clientId);
+    expect(responseParameters.clientSecret).toStrictEqual(
+      parameters.clientSecret,
+    );
   });
 });

--- a/sdk/interfaces/__tests__/index.test.js
+++ b/sdk/interfaces/__tests__/index.test.js
@@ -3,7 +3,7 @@ import makeRequest from '../../requests';
 import { getParameters } from '../../configuration';
 
 jest.mock('../../requests');
-const { REQUEST_TYPES } = jest.requireActual('../../requests');
+const REQUEST_TYPES = jest.requireActual('../../requests/constants');
 const requestFailedMessage = "Couldn't make request";
 
 describe('initialize', () => {

--- a/sdk/interfaces/__tests__/index.test.js
+++ b/sdk/interfaces/__tests__/index.test.js
@@ -1,4 +1,4 @@
-import { initialize, getToken } from '../index';
+import { initialize, getToken, refreshToken } from '../index';
 import makeRequest from '../../requests';
 import { getParameters } from '../../configuration';
 
@@ -43,6 +43,34 @@ describe('getToken', () => {
     }
     expect(makeRequest).toHaveBeenCalledTimes(1);
     expect(makeRequest).toHaveBeenCalledWith(REQUEST_TYPES.GET_TOKEN);
+    expect.assertions(3);
+  });
+});
+
+describe('refreshToken', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls refreshToken correctly', async () => {
+    const newToken = '041a156232ac43c6b719c57b7217c9ee';
+    makeRequest.mockReturnValue(Promise.resolve(newToken));
+
+    const response = await refreshToken();
+
+    expect(response).toBe(newToken);
+  });
+
+  it('calls refreshToken incorrectly', async () => {
+    makeRequest.mockReturnValue(
+      Promise.reject(new Error("Couldn't make request")),
+    );
+    try {
+      await refreshToken();
+    } catch (error) {
+      expect(error).toMatchObject(Error("Couldn't make request"));
+    }
+
+    expect(makeRequest).toHaveBeenCalledTimes(1);
+    expect(makeRequest).toHaveBeenCalledWith(REQUEST_TYPES.GET_REFRESH_TOKEN);
     expect.assertions(3);
   });
 });

--- a/sdk/interfaces/__tests__/index.test.js
+++ b/sdk/interfaces/__tests__/index.test.js
@@ -4,6 +4,7 @@ import { getParameters } from '../../configuration';
 
 jest.mock('../../requests');
 const { REQUEST_TYPES } = jest.requireActual('../../requests');
+const requestFailedMessage = "Couldn't make request";
 
 describe('initialize', () => {
   const parameters = {
@@ -61,12 +62,12 @@ describe('refreshToken', () => {
 
   it('calls refreshToken incorrectly', async () => {
     makeRequest.mockReturnValue(
-      Promise.reject(new Error("Couldn't make request")),
+      Promise.reject(new Error(requestFailedMessage)),
     );
     try {
       await refreshToken();
     } catch (error) {
-      expect(error).toMatchObject(Error("Couldn't make request"));
+      expect(error).toMatchObject(Error(requestFailedMessage));
     }
 
     expect(makeRequest).toHaveBeenCalledTimes(1);

--- a/sdk/interfaces/__tests__/login.test.js
+++ b/sdk/interfaces/__tests__/login.test.js
@@ -2,7 +2,7 @@ import { login } from '../index';
 import makeRequest from '../../requests';
 
 jest.mock('../../requests');
-const { REQUEST_TYPES } = jest.requireActual('../../requests');
+const REQUEST_TYPES = jest.requireActual('../../requests/constants');
 
 afterEach(() => jest.clearAllMocks());
 

--- a/sdk/interfaces/__tests__/login.test.js
+++ b/sdk/interfaces/__tests__/login.test.js
@@ -1,8 +1,8 @@
 import { login } from '../index';
 import makeRequest from '../../requests';
+import REQUEST_TYPES from '../../requests/constants';
 
 jest.mock('../../requests');
-const REQUEST_TYPES = jest.requireActual('../../requests/constants');
 
 afterEach(() => jest.clearAllMocks());
 

--- a/sdk/interfaces/__tests__/refreshToken.test.js
+++ b/sdk/interfaces/__tests__/refreshToken.test.js
@@ -1,0 +1,37 @@
+import makeRequest from '../../requests';
+import { refreshToken } from '../index';
+import REQUEST_TYPES from '../../requests/constants';
+
+const requestFailedMessage = "Couldn't make request";
+
+jest.mock('../../requests');
+
+afterEach(() => jest.clearAllMocks());
+
+describe('refreshToken', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls refreshToken correctly', async () => {
+    const newToken = '041a156232ac43c6b719c57b7217c9ee';
+    makeRequest.mockReturnValue(Promise.resolve(newToken));
+
+    const response = await refreshToken();
+
+    expect(response).toBe(newToken);
+  });
+
+  it('calls refreshToken incorrectly', async () => {
+    makeRequest.mockReturnValue(
+      Promise.reject(new Error(requestFailedMessage)),
+    );
+    try {
+      await refreshToken();
+    } catch (error) {
+      expect(error).toMatchObject(Error(requestFailedMessage));
+    }
+
+    expect(makeRequest).toHaveBeenCalledTimes(1);
+    expect(makeRequest).toHaveBeenCalledWith(REQUEST_TYPES.GET_REFRESH_TOKEN);
+    expect.assertions(3);
+  });
+});

--- a/sdk/interfaces/index.js
+++ b/sdk/interfaces/index.js
@@ -11,11 +11,8 @@ const getToken = () => makeRequest(REQUEST_TYPES.GET_TOKEN);
 
 const refreshToken = async () => {
   try {
-    const response = makeRequest(REQUEST_TYPES.GET_REFRESH_TOKEN);
-    console.log(response);
-    return response;
+    return makeRequest(REQUEST_TYPES.GET_REFRESH_TOKEN);
   } catch (error) {
-    console.log(error);
     return error;
   }
 };

--- a/sdk/interfaces/index.js
+++ b/sdk/interfaces/index.js
@@ -9,4 +9,15 @@ const login = () => makeRequest(REQUEST_TYPES.LOGIN);
 
 const getToken = () => makeRequest(REQUEST_TYPES.GET_TOKEN);
 
-export { initialize, login, getToken };
+const refreshToken = async () => {
+  try {
+    const response = makeRequest(REQUEST_TYPES.GET_REFRESH_TOKEN);
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.log(error);
+    return error;
+  }
+};
+
+export { initialize, login, getToken, refreshToken };

--- a/sdk/interfaces/index.js
+++ b/sdk/interfaces/index.js
@@ -9,12 +9,6 @@ const login = () => makeRequest(REQUEST_TYPES.LOGIN);
 
 const getToken = () => makeRequest(REQUEST_TYPES.GET_TOKEN);
 
-const refreshToken = async () => {
-  try {
-    return makeRequest(REQUEST_TYPES.GET_REFRESH_TOKEN);
-  } catch (error) {
-    return error;
-  }
-};
+const refreshToken = () => makeRequest(REQUEST_TYPES.GET_REFRESH_TOKEN);
 
 export { initialize, login, getToken, refreshToken };

--- a/sdk/interfaces/index.js
+++ b/sdk/interfaces/index.js
@@ -1,4 +1,5 @@
-import makeRequest, { REQUEST_TYPES } from '../requests';
+import makeRequest from '../requests';
+import REQUEST_TYPES from '../requests/constants';
 import { setParameters } from '../configuration';
 
 const initialize = (redirectUri, clientId, clientSecret) => {

--- a/sdk/requests/__tests__/getToken.test.js
+++ b/sdk/requests/__tests__/getToken.test.js
@@ -1,0 +1,97 @@
+import { fetch } from 'react-native-ssl-pinning';
+import REQUEST_TYPES from '../constants';
+import { getParameters } from '../../configuration';
+import getTokenOrRefresh from '../getTokenOrRefresh';
+
+jest.mock('../../configuration');
+
+jest.mock('react-native-ssl-pinning', () => ({
+  fetch: jest.fn(),
+}));
+
+describe('getToken', () => {
+  it('calls getToken with correct code', async () => {
+    const code = 'f24df0c4fcb142328b843d49753946af';
+    const redirectUri = 'uri';
+    const tokenEndpoint = 'https://auth-testing.iduruguay.gub.uy/oidc/v1/token';
+    getParameters.mockReturnValue({
+      clientId: '898562',
+      clientSecret: 'cdc04f19ac2s2f5h8f6we6d42b37e85a63f1w2e5f6sd8a4484b6b94b',
+      redirectUri,
+      code,
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            access_token: 'c9747e3173544b7b870d48aeafa0f661',
+            expires_in: 3600,
+            id_token:
+              'eyJhbGciOiJSUzI1NiIsImtpZCI6IjdhYThlN2YzOTE2ZGNiM2YyYTUxMWQzY2ZiMTk4YmY0In0.eyJpc3MiOiJodHRwczovL2F1dGgtdGVzdGluZy5pZHVydWd1YXkuZ3ViLnV5L29pZGMvdjEiLCJzdWIiOiI1ODU5IiwiYXVkIjoiODk0MzI5IiwiZXhwIjoxNjAxNTA2Nzc5LCJpYXQiOjE2MDE1MDYxNzksImF1dGhfdGltZSI6MTYwMTUwMTA0OSwiYW1yIjpbInVybjppZHVydWd1YXk6YW06cGFzc3dvcmQiXSwiYWNyIjoidXJuOmlkdXJ1Z3VheTpuaWQ6MSIsImF0X2hhc2giOiJmZ1pFMG1DYml2ZmxBcV95NWRTT09RIn0.r2kRakfFjIXBSWlvAqY-hh9A5Em4n5SWIn9Dr0IkVvnikoAh_E1OPg1o0IT1RW-0qIt0rfkoPUDCCPNrl6d_uNwabsDV0r2LgBSAhjFIQigM37H1buCAn6A5kiUNh8h_zxKxwA8qqia7tql9PUYwNkgslAjgCKR79imMz4j53iw',
+            refresh_token: '041a156232ac43c6b719c57b7217c9ee',
+            token_type: 'bearer',
+          }),
+      }),
+    );
+
+    const encodedCredentials =
+      'ODk4NTYyOmNkYzA0ZjE5YWMyczJmNWg4ZjZ3ZTZkNDJiMzdlODVhNjNmMXcyZTVmNnNkOGE0NDg0YjZiOTRi';
+
+    const response = await getTokenOrRefresh(REQUEST_TYPES.GET_TOKEN);
+
+    expect(fetch).toHaveBeenCalledWith(tokenEndpoint, {
+      method: 'POST',
+      sslPinning: {
+        certs: ['certificate'],
+      },
+      headers: {
+        Authorization: `Basic ${encodedCredentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        Accept: 'application/json',
+      },
+      body: `grant_type=authorization_code&code=${code}&redirect_uri=${redirectUri}`,
+    });
+
+    expect(response).toBe('c9747e3173544b7b870d48aeafa0f661');
+  });
+
+  it('calls getToken with incorrect clientId or clientSecret or returns incorrect code', async () => {
+    const error = 'invalid_grant';
+    const errorDescription =
+      'The provided authorization grant or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client';
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 400,
+        json: () =>
+          Promise.resolve({
+            error,
+            error_description: errorDescription,
+          }),
+      }),
+    );
+
+    try {
+      await getTokenOrRefresh(REQUEST_TYPES.GET_TOKEN);
+    } catch (err) {
+      expect(err).toStrictEqual({
+        error,
+        error_description: errorDescription,
+      });
+    }
+    expect.assertions(1);
+  });
+
+  it('calls getToken and fetch fails', async () => {
+    const error = Error('error');
+    fetch.mockImplementation(() => Promise.reject(error));
+    try {
+      await getTokenOrRefresh(REQUEST_TYPES.GET_TOKEN);
+    } catch (err) {
+      expect(err).toBe(error);
+    }
+    expect.assertions(1);
+  });
+});

--- a/sdk/requests/__tests__/index.test.js
+++ b/sdk/requests/__tests__/index.test.js
@@ -121,7 +121,7 @@ describe('getToken', () => {
 
 
 describe('makeRequest refreshToken', () => {
-  it('calls refreshToken with correct code', async () => {
+  it('calls refreshToken with correct refreshToken', async () => {
     // Mockear la funcion fetch
     fetch.mockImplementation(() =>
       Promise.resolve({
@@ -174,6 +174,43 @@ describe('makeRequest refreshToken', () => {
 
     // Chequeo de respuestas
     expect(response).toBe('c9747e3173544b7b870d48aeafa0f661');
+  });
+
+  it('calls getToken with incorrect clientId or clientSecret or refreshToken', async () => {
+    const error = 'invalid_grant';
+    const errorDescription =
+      'The provided authorization grant or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client';
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 400,
+        json: () =>
+          Promise.resolve({
+            error,
+            error_description: errorDescription,
+          }),
+      }),
+    );
+
+    try {
+      await makeRequest(REQUEST_TYPES.GET_REFRESH_TOKEN);
+    } catch (err) {
+      expect(err).toStrictEqual({
+        error,
+        error_description: errorDescription,
+      });
+    }
+    expect.assertions(1);
+  });
+  it('calls refreshToken and fetch fails', async () => {
+    const error = Error('error');
+    fetch.mockImplementation(() => Promise.reject(error));
+    try {
+      await makeRequest(REQUEST_TYPES.GET_REFRESH_TOKEN);
+    } catch (err) {
+      expect(err).toBe(error);
+    }
+    expect.assertions(1);
   });
 }); 
 

--- a/sdk/requests/__tests__/index.test.js
+++ b/sdk/requests/__tests__/index.test.js
@@ -119,6 +119,64 @@ describe('getToken', () => {
   });
 });
 
+
+describe('makeRequest refreshToken', () => {
+  it('calls refreshToken with correct code', async () => {
+    // Mockear la funcion fetch
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            access_token: 'c9747e3173544b7b870d48aeafa0f661',
+            expires_in: 3600,
+            id_token:
+              'eyJhbGciOiJSUzI1NiIsImtpZCI6IjdhYThlN2YzOTE2ZGNiM2YyYTUxMWQzY2ZiMTk4YmY0In0.eyJpc3MiOiJodHRwczovL2F1dGgtdGVzdGluZy5pZHVydWd1YXkuZ3ViLnV5L29pZGMvdjEiLCJzdWIiOiI1ODU5IiwiYXVkIjoiODk0MzI5IiwiZXhwIjoxNjAxNTA2Nzc5LCJpYXQiOjE2MDE1MDYxNzksImF1dGhfdGltZSI6MTYwMTUwMTA0OSwiYW1yIjpbInVybjppZHVydWd1YXk6YW06cGFzc3dvcmQiXSwiYWNyIjoidXJuOmlkdXJ1Z3VheTpuaWQ6MSIsImF0X2hhc2giOiJmZ1pFMG1DYml2ZmxBcV95NWRTT09RIn0.r2kRakfFjIXBSWlvAqY-hh9A5Em4n5SWIn9Dr0IkVvnikoAh_E1OPg1o0IT1RW-0qIt0rfkoPUDCCPNrl6d_uNwabsDV0r2LgBSAhjFIQigM37H1buCAn6A5kiUNh8h_zxKxwA8qqia7tql9PUYwNkgslAjgCKR79imMz4j53iw',
+            refresh_token: '041a156232ac43c6b719c57b7217c9ee',
+            token_type: 'bearer',
+          }),
+      }),
+    );
+
+    const clientId = '898562';
+    const clientSecret =
+      'cdc04f19ac2s2f5h8f6we6d42b37e85a63f1w2e5f6sd8a4484b6b94b';
+    const tokenEndpoint = 'https://auth-testing.iduruguay.gub.uy/oidc/v1/token';
+    const refreshToken = '541a156232ac43c6b719c57b7217c9ea';
+
+    // Mockear getParameters
+    getParameters.mockReturnValue({
+      clientId,
+      clientSecret,
+      refreshToken,
+    });
+
+    const encodedCredentials =
+      'ODk4NTYyOmNkYzA0ZjE5YWMyczJmNWg4ZjZ3ZTZkNDJiMzdlODVhNjNmMXcyZTVmNnNkOGE0NDg0YjZiOTRi';
+
+    const response = await makeRequest(REQUEST_TYPES.GET_REFRESH_TOKEN);
+
+    expect.assertions(2);
+
+    // Chequeo de parametros enviados
+    expect(fetch).toHaveBeenCalledWith(tokenEndpoint, {
+      method: 'POST',
+      sslPinning: {
+        certs: ['certificate'],
+      },
+      headers: {
+        Authorization: `Basic ${encodedCredentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        Accept: 'application/json',
+      },
+      body: `grant_type=refresh_token&refresh_token=${refreshToken}`,
+    });
+
+    // Chequeo de respuestas
+    expect(response).toBe('c9747e3173544b7b870d48aeafa0f661');
+  });
+}); 
+
 describe('default', () => {
   it('calls default', async () => {
     const response = await makeRequest('default');

--- a/sdk/requests/__tests__/index.test.js
+++ b/sdk/requests/__tests__/index.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import { fetch } from 'react-native-ssl-pinning';
-import makeRequest, { REQUEST_TYPES } from '../index';
+import makeRequest from '../index';
+import REQUEST_TYPES from '../constants';
 import login from '../login';
 import { getParameters } from '../../configuration';
 

--- a/sdk/requests/__tests__/index.test.js
+++ b/sdk/requests/__tests__/index.test.js
@@ -1,11 +1,10 @@
-/* eslint-disable sonarjs/no-identical-functions */
-import { fetch } from 'react-native-ssl-pinning';
 import makeRequest from '../index';
 import REQUEST_TYPES from '../constants';
 import login from '../login';
-import { getParameters } from '../../configuration';
+import getTokenOrRefresh from '../getTokenOrRefresh';
 
 jest.mock('../login');
+jest.mock('../getTokenOrRefresh');
 jest.mock('../../configuration');
 
 afterEach(() => jest.clearAllMocks());
@@ -35,83 +34,16 @@ describe('login', () => {
 });
 
 describe('getToken', () => {
-  it('calls getToken with correct code', async () => {
-    const code = 'f24df0c4fcb142328b843d49753946af';
-    const redirectUri = 'uri';
-    const tokenEndpoint = 'https://auth-testing.iduruguay.gub.uy/oidc/v1/token';
-    getParameters.mockReturnValue({
-      clientId: '898562',
-      clientSecret: 'cdc04f19ac2s2f5h8f6we6d42b37e85a63f1w2e5f6sd8a4484b6b94b',
-      redirectUri,
-      code,
-    });
-
-    fetch.mockImplementation(() =>
-      Promise.resolve({
-        status: 200,
-        json: () =>
-          Promise.resolve({
-            access_token: 'c9747e3173544b7b870d48aeafa0f661',
-            expires_in: 3600,
-            id_token:
-              'eyJhbGciOiJSUzI1NiIsImtpZCI6IjdhYThlN2YzOTE2ZGNiM2YyYTUxMWQzY2ZiMTk4YmY0In0.eyJpc3MiOiJodHRwczovL2F1dGgtdGVzdGluZy5pZHVydWd1YXkuZ3ViLnV5L29pZGMvdjEiLCJzdWIiOiI1ODU5IiwiYXVkIjoiODk0MzI5IiwiZXhwIjoxNjAxNTA2Nzc5LCJpYXQiOjE2MDE1MDYxNzksImF1dGhfdGltZSI6MTYwMTUwMTA0OSwiYW1yIjpbInVybjppZHVydWd1YXk6YW06cGFzc3dvcmQiXSwiYWNyIjoidXJuOmlkdXJ1Z3VheTpuaWQ6MSIsImF0X2hhc2giOiJmZ1pFMG1DYml2ZmxBcV95NWRTT09RIn0.r2kRakfFjIXBSWlvAqY-hh9A5Em4n5SWIn9Dr0IkVvnikoAh_E1OPg1o0IT1RW-0qIt0rfkoPUDCCPNrl6d_uNwabsDV0r2LgBSAhjFIQigM37H1buCAn6A5kiUNh8h_zxKxwA8qqia7tql9PUYwNkgslAjgCKR79imMz4j53iw',
-            refresh_token: '041a156232ac43c6b719c57b7217c9ee',
-            token_type: 'bearer',
-          }),
-      }),
-    );
-
-    const encodedCredentials =
-      'ODk4NTYyOmNkYzA0ZjE5YWMyczJmNWg4ZjZ3ZTZkNDJiMzdlODVhNjNmMXcyZTVmNnNkOGE0NDg0YjZiOTRi';
-
+  it('calls getToken and works correctly', async () => {
+    const token = 'token';
+    getTokenOrRefresh.mockImplementation(() => Promise.resolve(token));
     const response = await makeRequest(REQUEST_TYPES.GET_TOKEN);
-
-    expect(fetch).toHaveBeenCalledWith(tokenEndpoint, {
-      method: 'POST',
-      sslPinning: {
-        certs: ['certificate'],
-      },
-      headers: {
-        Authorization: `Basic ${encodedCredentials}`,
-        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-        Accept: 'application/json',
-      },
-      body: `grant_type=authorization_code&code=${code}&redirect_uri=${redirectUri}`,
-    });
-
-    expect(response).toBe('c9747e3173544b7b870d48aeafa0f661');
+    expect(response).toBe(token);
   });
 
-  it('calls getToken with incorrect clientId or clientSecret or returns incorrect code', async () => {
-    const error = 'invalid_grant';
-    const errorDescription =
-      'The provided authorization grant or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client';
-
-    fetch.mockImplementation(() =>
-      Promise.resolve({
-        status: 400,
-        json: () =>
-          Promise.resolve({
-            error,
-            error_description: errorDescription,
-          }),
-      }),
-    );
-
-    try {
-      await makeRequest(REQUEST_TYPES.GET_TOKEN);
-    } catch (err) {
-      expect(err).toStrictEqual({
-        error,
-        error_description: errorDescription,
-      });
-    }
-    expect.assertions(1);
-  });
-
-  it('calls getToken and fetch fails', async () => {
+  it('calls getToken and fails', async () => {
     const error = Error('error');
-    fetch.mockImplementation(() => Promise.reject(error));
+    getTokenOrRefresh.mockImplementation(() => Promise.reject(error));
     try {
       await makeRequest(REQUEST_TYPES.GET_TOKEN);
     } catch (err) {
@@ -121,91 +53,17 @@ describe('getToken', () => {
   });
 });
 
-describe('makeRequest refreshToken', () => {
-  it('calls refreshToken with correct refreshToken', async () => {
-    // Mockear la funcion fetch
-    fetch.mockImplementation(() =>
-      Promise.resolve({
-        status: 200,
-        json: () =>
-          Promise.resolve({
-            access_token: 'c9747e3173544b7b870d48aeafa0f661',
-            expires_in: 3600,
-            id_token:
-              'eyJhbGciOiJSUzI1NiIsImtpZCI6IjdhYThlN2YzOTE2ZGNiM2YyYTUxMWQzY2ZiMTk4YmY0In0.eyJpc3MiOiJodHRwczovL2F1dGgtdGVzdGluZy5pZHVydWd1YXkuZ3ViLnV5L29pZGMvdjEiLCJzdWIiOiI1ODU5IiwiYXVkIjoiODk0MzI5IiwiZXhwIjoxNjAxNTA2Nzc5LCJpYXQiOjE2MDE1MDYxNzksImF1dGhfdGltZSI6MTYwMTUwMTA0OSwiYW1yIjpbInVybjppZHVydWd1YXk6YW06cGFzc3dvcmQiXSwiYWNyIjoidXJuOmlkdXJ1Z3VheTpuaWQ6MSIsImF0X2hhc2giOiJmZ1pFMG1DYml2ZmxBcV95NWRTT09RIn0.r2kRakfFjIXBSWlvAqY-hh9A5Em4n5SWIn9Dr0IkVvnikoAh_E1OPg1o0IT1RW-0qIt0rfkoPUDCCPNrl6d_uNwabsDV0r2LgBSAhjFIQigM37H1buCAn6A5kiUNh8h_zxKxwA8qqia7tql9PUYwNkgslAjgCKR79imMz4j53iw',
-            refresh_token: '041a156232ac43c6b719c57b7217c9ee',
-            token_type: 'bearer',
-          }),
-      }),
-    );
-
-    const clientId = '898562';
-    const clientSecret =
-      'cdc04f19ac2s2f5h8f6we6d42b37e85a63f1w2e5f6sd8a4484b6b94b';
-    const tokenEndpoint = 'https://auth-testing.iduruguay.gub.uy/oidc/v1/token';
-    const refreshToken = '541a156232ac43c6b719c57b7217c9ea';
-
-    // Mockear getParameters
-    getParameters.mockReturnValue({
-      clientId,
-      clientSecret,
-      refreshToken,
-    });
-
-    const encodedCredentials =
-      'ODk4NTYyOmNkYzA0ZjE5YWMyczJmNWg4ZjZ3ZTZkNDJiMzdlODVhNjNmMXcyZTVmNnNkOGE0NDg0YjZiOTRi';
-
+describe('refreshToken', () => {
+  it('calls refreshToken and works correctly', async () => {
+    const token = 'token';
+    getTokenOrRefresh.mockImplementation(() => Promise.resolve(token));
     const response = await makeRequest(REQUEST_TYPES.GET_REFRESH_TOKEN);
-
-    expect.assertions(2);
-
-    // Chequeo de parametros enviados
-    expect(fetch).toHaveBeenCalledWith(tokenEndpoint, {
-      method: 'POST',
-      sslPinning: {
-        certs: ['certificate'],
-      },
-      headers: {
-        Authorization: `Basic ${encodedCredentials}`,
-        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-        Accept: 'application/json',
-      },
-      body: `grant_type=refresh_token&refresh_token=${refreshToken}`,
-    });
-
-    // Chequeo de respuestas
-    expect(response).toBe('c9747e3173544b7b870d48aeafa0f661');
+    expect(response).toBe(token);
   });
 
-  it('calls getToken with incorrect clientId or clientSecret or refreshToken', async () => {
-    const error = 'invalid_grant';
-    const errorDescription =
-      'The provided authorization grant or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client';
-
-    fetch.mockImplementation(() =>
-      Promise.resolve({
-        status: 400,
-        json: () =>
-          Promise.resolve({
-            error,
-            error_description: errorDescription,
-          }),
-      }),
-    );
-
-    try {
-      await makeRequest(REQUEST_TYPES.GET_REFRESH_TOKEN);
-    } catch (err) {
-      expect(err).toStrictEqual({
-        error,
-        error_description: errorDescription,
-      });
-    }
-    expect.assertions(1);
-  });
-  it('calls refreshToken and fetch fails', async () => {
+  it('calls refreshToken and fails', async () => {
     const error = Error('error');
-    fetch.mockImplementation(() => Promise.reject(error));
+    getTokenOrRefresh.mockImplementation(() => Promise.reject(error));
     try {
       await makeRequest(REQUEST_TYPES.GET_REFRESH_TOKEN);
     } catch (err) {

--- a/sdk/requests/__tests__/index.test.js
+++ b/sdk/requests/__tests__/index.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-identical-functions */
 import { fetch } from 'react-native-ssl-pinning';
 import makeRequest, { REQUEST_TYPES } from '../index';
 import login from '../login';

--- a/sdk/requests/__tests__/index.test.js
+++ b/sdk/requests/__tests__/index.test.js
@@ -119,7 +119,6 @@ describe('getToken', () => {
   });
 });
 
-
 describe('makeRequest refreshToken', () => {
   it('calls refreshToken with correct refreshToken', async () => {
     // Mockear la funcion fetch
@@ -212,7 +211,7 @@ describe('makeRequest refreshToken', () => {
     }
     expect.assertions(1);
   });
-}); 
+});
 
 describe('default', () => {
   it('calls default', async () => {

--- a/sdk/requests/__tests__/refreshToken.test.js
+++ b/sdk/requests/__tests__/refreshToken.test.js
@@ -1,0 +1,104 @@
+import { fetch } from 'react-native-ssl-pinning';
+import REQUEST_TYPES from '../constants';
+import { getParameters } from '../../configuration';
+import getTokenOrRefresh from '../getTokenOrRefresh';
+
+jest.mock('../../configuration');
+
+jest.mock('react-native-ssl-pinning', () => ({
+  fetch: jest.fn(),
+}));
+
+describe('refreshToken', () => {
+  it('calls refreshToken with correct refreshToken', async () => {
+    // Mockear la funcion fetch
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            access_token: 'c9747e3173544b7b870d48aeafa0f661',
+            expires_in: 3600,
+            id_token:
+              'eyJhbGciOiJSUzI1NiIsImtpZCI6IjdhYThlN2YzOTE2ZGNiM2YyYTUxMWQzY2ZiMTk4YmY0In0.eyJpc3MiOiJodHRwczovL2F1dGgtdGVzdGluZy5pZHVydWd1YXkuZ3ViLnV5L29pZGMvdjEiLCJzdWIiOiI1ODU5IiwiYXVkIjoiODk0MzI5IiwiZXhwIjoxNjAxNTA2Nzc5LCJpYXQiOjE2MDE1MDYxNzksImF1dGhfdGltZSI6MTYwMTUwMTA0OSwiYW1yIjpbInVybjppZHVydWd1YXk6YW06cGFzc3dvcmQiXSwiYWNyIjoidXJuOmlkdXJ1Z3VheTpuaWQ6MSIsImF0X2hhc2giOiJmZ1pFMG1DYml2ZmxBcV95NWRTT09RIn0.r2kRakfFjIXBSWlvAqY-hh9A5Em4n5SWIn9Dr0IkVvnikoAh_E1OPg1o0IT1RW-0qIt0rfkoPUDCCPNrl6d_uNwabsDV0r2LgBSAhjFIQigM37H1buCAn6A5kiUNh8h_zxKxwA8qqia7tql9PUYwNkgslAjgCKR79imMz4j53iw',
+            refresh_token: '041a156232ac43c6b719c57b7217c9ee',
+            token_type: 'bearer',
+          }),
+      }),
+    );
+
+    const clientId = '898562';
+    const clientSecret =
+      'cdc04f19ac2s2f5h8f6we6d42b37e85a63f1w2e5f6sd8a4484b6b94b';
+    const tokenEndpoint = 'https://auth-testing.iduruguay.gub.uy/oidc/v1/token';
+    const refreshToken = '541a156232ac43c6b719c57b7217c9ea';
+
+    // Mockear getParameters
+    getParameters.mockReturnValue({
+      clientId,
+      clientSecret,
+      refreshToken,
+    });
+
+    const encodedCredentials =
+      'ODk4NTYyOmNkYzA0ZjE5YWMyczJmNWg4ZjZ3ZTZkNDJiMzdlODVhNjNmMXcyZTVmNnNkOGE0NDg0YjZiOTRi';
+
+    const response = await getTokenOrRefresh(REQUEST_TYPES.GET_REFRESH_TOKEN);
+
+    expect.assertions(2);
+
+    // Chequeo de parametros enviados
+    expect(fetch).toHaveBeenCalledWith(tokenEndpoint, {
+      method: 'POST',
+      sslPinning: {
+        certs: ['certificate'],
+      },
+      headers: {
+        Authorization: `Basic ${encodedCredentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        Accept: 'application/json',
+      },
+      body: `grant_type=refresh_token&refresh_token=${refreshToken}`,
+    });
+
+    // Chequeo de respuestas
+    expect(response).toBe('c9747e3173544b7b870d48aeafa0f661');
+  });
+
+  it('calls refreshToken with incorrect clientId or clientSecret or refreshToken', async () => {
+    const error = 'invalid_grant';
+    const errorDescription =
+      'The provided authorization grant or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client';
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 400,
+        json: () =>
+          Promise.resolve({
+            error,
+            error_description: errorDescription,
+          }),
+      }),
+    );
+
+    try {
+      await getTokenOrRefresh(REQUEST_TYPES.GET_REFRESH_TOKEN);
+    } catch (err) {
+      expect(err).toStrictEqual({
+        error,
+        error_description: errorDescription,
+      });
+    }
+    expect.assertions(1);
+  });
+  it('calls refreshToken and fetch fails', async () => {
+    const error = Error('error');
+    fetch.mockImplementation(() => Promise.reject(error));
+    try {
+      await getTokenOrRefresh(REQUEST_TYPES.GET_REFRESH_TOKEN);
+    } catch (err) {
+      expect(err).toBe(error);
+    }
+    expect.assertions(1);
+  });
+});

--- a/sdk/requests/__tests__/refreshToken.test.js
+++ b/sdk/requests/__tests__/refreshToken.test.js
@@ -45,8 +45,6 @@ describe('refreshToken', () => {
 
     const response = await getTokenOrRefresh(REQUEST_TYPES.GET_REFRESH_TOKEN);
 
-    expect.assertions(2);
-
     // Chequeo de parametros enviados
     expect(fetch).toHaveBeenCalledWith(tokenEndpoint, {
       method: 'POST',
@@ -91,6 +89,7 @@ describe('refreshToken', () => {
     }
     expect.assertions(1);
   });
+
   it('calls refreshToken and fetch fails', async () => {
     const error = Error('error');
     fetch.mockImplementation(() => Promise.reject(error));

--- a/sdk/requests/constants.js
+++ b/sdk/requests/constants.js
@@ -1,0 +1,7 @@
+const REQUEST_TYPES = {
+  LOGIN: 'login',
+  GET_TOKEN: 'getToken',
+  GET_REFRESH_TOKEN: 'getRefreshToken',
+};
+
+export default REQUEST_TYPES;

--- a/sdk/requests/getToken.js
+++ b/sdk/requests/getToken.js
@@ -1,0 +1,66 @@
+import { encode } from 'base-64';
+import { fetch } from 'react-native-ssl-pinning';
+import { getParameters, setParameters } from '../configuration';
+import { tokenEndpoint } from './endpoints';
+import REQUEST_TYPES from './constants';
+
+const getToken = async type => {
+  const parameters = getParameters();
+
+  // Codificar en base64 el clientId y el clientSecret,
+  // siguiendo el esquema de autenticación HTTP Basic Auth.
+  const encodedCredentials = encode(
+    `${parameters.clientId}:${parameters.clientSecret}`,
+  );
+  // En caso de que el request sea GET_TOKEN el body de la request contendrá el code obtenido
+  // durante el login, y la redirect uri correspondiente.
+  let bodyString = `grant_type=authorization_code&code=${parameters.code}&redirect_uri=${parameters.redirectUri}`;
+  // En caso de que el request sea GET_REFRESH_TOKEN el body de la request contendrá grant_type 'refresh_token' y
+  // el refresh token obtenido en get token
+  if (type === REQUEST_TYPES.GET_REFRESH_TOKEN)
+    bodyString = `grant_type=refresh_token&refresh_token=${parameters.refreshToken}`;
+
+  try {
+    // Se arma la solicitud a enviar al tokenEndpoint, tomando
+    // los datos de autenticación codificados
+    const response = await fetch(tokenEndpoint, {
+      method: 'POST',
+      sslPinning: {
+        certs: ['certificate'],
+      },
+      headers: {
+        Authorization: `Basic ${encodedCredentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        Accept: 'application/json',
+      },
+      body: bodyString,
+    });
+
+    const { status } = response;
+    const responseJson = await response.json();
+
+    // En caso de error se devuelve la respuesta,
+    // rechazando la promesa.
+    if (status !== 200) {
+      return Promise.reject(responseJson);
+    }
+
+    // En caso de una respuesta correcta se definen los
+    // parámetros correspondientes en configuración.
+    setParameters({
+      accessToken: responseJson.access_token,
+      refreshToken: responseJson.refresh_token,
+      tokenType: responseJson.token_type,
+      expiresIn: responseJson.expires_in,
+      idToken: responseJson.id_token,
+    });
+    return Promise.resolve(responseJson.access_token);
+  } catch (error) {
+    // Si existe algun error, se
+    // rechaza la promesa y se devuelve el
+    // error.
+    return Promise.reject(error);
+  }
+};
+
+export default getToken;

--- a/sdk/requests/getTokenOrRefresh.js
+++ b/sdk/requests/getTokenOrRefresh.js
@@ -4,7 +4,7 @@ import { getParameters, setParameters } from '../configuration';
 import { tokenEndpoint } from './endpoints';
 import REQUEST_TYPES from './constants';
 
-const getToken = async type => {
+const getTokenOrRefresh = async type => {
   const parameters = getParameters();
 
   // Codificar en base64 el clientId y el clientSecret,
@@ -63,4 +63,4 @@ const getToken = async type => {
   }
 };
 
-export default getToken;
+export default getTokenOrRefresh;

--- a/sdk/requests/index.js
+++ b/sdk/requests/index.js
@@ -7,7 +7,8 @@ const makeRequest = async type => {
     case REQUEST_TYPES.LOGIN: {
       return login();
     }
-    case REQUEST_TYPES.GET_TOKEN || REQUEST_TYPES.GET_REFRESH_TOKEN: {
+    case REQUEST_TYPES.GET_TOKEN:
+    case REQUEST_TYPES.GET_REFRESH_TOKEN: {
       return getTokenOrRefresh(type);
     }
     default:

--- a/sdk/requests/index.js
+++ b/sdk/requests/index.js
@@ -1,76 +1,14 @@
-import { encode } from 'base-64';
-import { fetch } from 'react-native-ssl-pinning';
-import { getParameters, setParameters } from '../configuration';
-import { tokenEndpoint } from './endpoints';
 import login from './login';
-
-export const REQUEST_TYPES = {
-  LOGIN: 'login',
-  GET_TOKEN: 'getToken',
-  GET_REFRESH_TOKEN: 'getRefreshToken',
-};
+import getToken from './getToken';
+import REQUEST_TYPES from './constants';
 
 const makeRequest = async type => {
-  const parameters = getParameters();
   switch (type) {
     case REQUEST_TYPES.LOGIN: {
       return login();
     }
-    case REQUEST_TYPES.GET_TOKEN:
-    case REQUEST_TYPES.GET_REFRESH_TOKEN: {
-      // Codificar en base64 el clientId y el clientSecret,
-      // siguiendo el esquema de autenticación HTTP Basic Auth.
-      const encodedCredentials = encode(
-        `${parameters.clientId}:${parameters.clientSecret}`,
-      );
-      // En caso de que el request sea GET_TOKEN el body de la request contendrá el code obtenido
-      // durante el login, y la redirect uri correspondiente.
-      let bodyString = `grant_type=authorization_code&code=${parameters.code}&redirect_uri=${parameters.redirectUri}`;
-      // En caso de que el request sea GET_REFRESH_TOKEN el body de la request contendrá grant_type 'refresh_token' y
-      // el refresh token obtenido en get token
-      if (type === REQUEST_TYPES.GET_REFRESH_TOKEN)
-        bodyString = `grant_type=refresh_token&refresh_token=${parameters.refreshToken}`;
-      try {
-        // Se arma la solicitud a enviar al tokenEndpoint, tomando
-        // los datos de autenticación codificados
-        const response = await fetch(tokenEndpoint, {
-          method: 'POST',
-          sslPinning: {
-            certs: ['certificate'],
-          },
-          headers: {
-            Authorization: `Basic ${encodedCredentials}`,
-            'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-            Accept: 'application/json',
-          },
-          body: bodyString,
-        });
-
-        const { status } = response;
-        const responseJson = await response.json();
-
-        // En caso de error se devuelve la respuesta,
-        // rechazando la promesa.
-        if (status !== 200) {
-          return Promise.reject(responseJson);
-        }
-
-        // En caso de una respuesta correcta se definen los
-        // parámetros correspondientes en configuración.
-        setParameters({
-          accessToken: responseJson.access_token,
-          refreshToken: responseJson.refresh_token,
-          tokenType: responseJson.token_type,
-          expiresIn: responseJson.expires_in,
-          idToken: responseJson.id_token,
-        });
-        return Promise.resolve(responseJson.access_token);
-      } catch (error) {
-        // Si existe algun error, se
-        // rechaza la promesa y se devuelve el
-        // error.
-        return Promise.reject(error);
-      }
+    case REQUEST_TYPES.GET_TOKEN || REQUEST_TYPES.GET_REFRESH_TOKEN: {
+      return getToken(type);
     }
     default:
       return 'default value';

--- a/sdk/requests/index.js
+++ b/sdk/requests/index.js
@@ -1,5 +1,5 @@
 import login from './login';
-import getToken from './getToken';
+import getTokenOrRefresh from './getTokenOrRefresh';
 import REQUEST_TYPES from './constants';
 
 const makeRequest = async type => {
@@ -8,7 +8,7 @@ const makeRequest = async type => {
       return login();
     }
     case REQUEST_TYPES.GET_TOKEN || REQUEST_TYPES.GET_REFRESH_TOKEN: {
-      return getToken(type);
+      return getTokenOrRefresh(type);
     }
     default:
       return 'default value';

--- a/sdk/requests/index.js
+++ b/sdk/requests/index.js
@@ -28,8 +28,7 @@ const makeRequest = async type => {
       let bodyString = `grant_type=authorization_code&code=${parameters.code}&redirect_uri=${parameters.redirectUri}`;
       // En caso de que el request sea GET_REFRESH_TOKEN el body de la request contendrá grant_type 'refresh_token' y
       // el refresh token obtenido en get token
-      // eslint-disable-next-line eqeqeq
-      if (type == REQUEST_TYPES.GET_REFRESH_TOKEN)
+      if (type === REQUEST_TYPES.GET_REFRESH_TOKEN)
         bodyString = `grant_type=refresh_token&refresh_token=${parameters.refreshToken}`;
       try {
         // Se arma la solicitud a enviar al tokenEndpoint, tomando


### PR DESCRIPTION
## Descripción

Se implementó la funcionalidad de Make Request Refresh Token, que a partir de un refresh_token obtiene un nuevo access_token.
La implementación actual requiere del uso de la librería 'react-native-ssl-pinning' que resuelve el problema del certificado autofirmado. Actualmente funciona únicamente en Android. También se implementó parcialmente la funcionalidad de refreshToken.

## Tests

Explique las pruebas unitarias realizadas. Por ejemplo, con una lista:
- [ ] Llamar a makeRequest con REQUEST_TYPES.GET_REFRESH_TOKEN y la información correspondiente, esperando la devolución del access token nuevo.
- [ ]   Llamar a makeRequest con REQUEST_TYPES.GET_REFRESH_TOKEN con parametros incorrectos, esperando una respuesta con status 400 y el contenido correspondiente.
- [ ]   Llamar a makeRequest con REQUEST_TYPES.GET_REFRESH_TOKEN cuando falla el fetch, esperando un mensaje de error.

- [ ]   Llamar a refreshToken, esperando un nuevo access_token.
- [ ]   Llamar a refreshToken, esperando un mensaje de error.

