### PR TITLE
Bugfix/dont clear initialized paramaters

### DIFF
--- a/sdk/configuration/__tests__/index.test.js
+++ b/sdk/configuration/__tests__/index.test.js
@@ -84,9 +84,9 @@ describe('configuration module', () => {
     });
     clearParameters();
     expect(getParameters()).toStrictEqual({
-      redirectUri: '',
-      clientId: '',
-      clientSecret: '',
+      redirectUri: 'redirectUri',
+      clientId: 'clientId2',
+      clientSecret: 'clientSecret',
       code: '',
       accessToken: '',
       refreshToken: '',

--- a/sdk/configuration/index.js
+++ b/sdk/configuration/index.js
@@ -20,7 +20,13 @@ const setParameters = params => {
 
 const clearParameters = () => {
   Object.keys(parameters).forEach(key => {
-    parameters[key] = '';
+    if (
+      key !== 'redirectUri' &&
+      key !== 'clientId' &&
+      key !== 'clientSecret' &&
+      key !== 'postLogoutRedirectUri'
+    )
+      parameters[key] = '';
   });
 };
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -8,7 +8,8 @@
     "testCoverage": "jest --coverage=true",
     "testWatch": "jest --watch --coverage=false --changedSince=origin/develop",
     "testDebug": "jest -o --watch --coverage=false",
-    "updateSnapshots": "jest -u --coverage=false"
+    "linter": "eslint .",
+    "linterFix": "eslint . --fix"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
## Descripción

Ahora la función `clearParameters` no elimina los valores de los parámetros que fueron inicializados con la función `initialize`.

## Tests

Explique las pruebas unitarias realizadas. Por ejemplo, con una lista:
  - Se actualizaron las pruebas del componente de configuración.

