### PR TITLE
Parsing state from url is now handled by the sdk

### DIFF
--- a/app/LoginButton/index.js
+++ b/app/LoginButton/index.js
@@ -48,11 +48,8 @@ const LoginButton = ({ handleUserInfo }) => {
 
   const handleLogout = async () => {
     try {
-      const postLogoutRedirectUriWithState = await logout();
-      const receivedState = postLogoutRedirectUriWithState.match(
-        /\?state=([^&]+)/,
-      );
-      if (receivedState) console.log(`State: ${receivedState[1]}`);
+      const state = await logout();
+      if (state) console.log(`State: ${state}`);
     } catch (err) {
       console.log(err);
     }

--- a/sdk/requests/__tests__/logout.test.js
+++ b/sdk/requests/__tests__/logout.test.js
@@ -34,10 +34,10 @@ describe('logout', () => {
           url: 'post_logout_redirect_uri?state=2KVAEzPpazbGFD5',
         });
     });
-    const redirectUri = await logout();
+    const state = await logout();
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
     expect(mockLinkingOpenUrl).toHaveBeenCalledWith(correctLogoutEndpoint1);
-    expect(redirectUri).toBe('post_logout_redirect_uri?state=2KVAEzPpazbGFD5');
+    expect(state).toBe('2KVAEzPpazbGFD5');
   });
 
   it('calls logout with idTokenHint and postLogoutRedirectUri but without state', async () => {
@@ -55,7 +55,7 @@ describe('logout', () => {
     const redirectUri = await logout();
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
     expect(mockLinkingOpenUrl).toHaveBeenCalledWith(correctLogoutEndpoint2);
-    expect(redirectUri).toBe('post_logout_redirect_uri');
+    expect(redirectUri).toBe(undefined);
   });
 
   it('calls logout with idTokenHint and state but without postLogoutRedirectUri', async () => {

--- a/sdk/requests/logout.js
+++ b/sdk/requests/logout.js
@@ -24,7 +24,8 @@ const logout = async () => {
     //  Si la url es igual a la postLogoutRedirectUri
     //  setteada, se limpian los parámetros del componente
     //  de configuración que correspondan y se resuelve la
-    //  promise. Si no, se rechaza la promise con un error.
+    //  promise, retornando si corresponde el parámetro state.
+    //  Si las url no coinciden, se rechaza la promise con un error.
     if (urlCheck === lowerCasePostLogoutRedirectUri) {
       clearParameters();
       resolveFunction();

--- a/sdk/requests/logout.js
+++ b/sdk/requests/logout.js
@@ -4,8 +4,8 @@ import { logoutEndpoint } from '../utils/endpoints';
 
 const logout = async () => {
   const parameters = getParameters();
-  const missingParamsMessage = 'Missing required parameter(s): ';
   const lowerCasePostLogoutRedirectUri = parameters.postLogoutRedirectUri.toLowerCase();
+  const missingParamsMessage = 'Missing required parameter(s): ';
   let resolveFunction;
   let rejectFunction;
 
@@ -25,12 +25,15 @@ const logout = async () => {
     //  setteada, se limpian los parámetros del componente
     //  de configuración que correspondan y se resuelve la
     //  promise. Si no, se rechaza la promise con un error.
-    if (
-      urlCheck === lowerCasePostLogoutRedirectUri ||
+    if (urlCheck === lowerCasePostLogoutRedirectUri) {
+      clearParameters();
+      resolveFunction();
+    } else if (
       urlCheck === `${lowerCasePostLogoutRedirectUri}?state=${parameters.state}`
     ) {
       clearParameters();
-      resolveFunction(urlCheck);
+      const state = urlCheck.match(/\?state=([^&]+)/);
+      resolveFunction(state[1]);
     } else rejectFunction(Error('Invalid post logout redirect uri'));
 
     // Se elimina el handler para los eventos url.


### PR DESCRIPTION
# Parsing state from url is now handled by the sdk

## Descripción

En caso de haber realizado la Logout Request pasando un parámetro state, el OP retornará al finalizar el cierre de sesión una url que contiene dicho state. Esta url era pasada al usuario directamente, cuando en realidad lo que le interesa es únicamente el state. Esto llevaba a que el usuario debiera parsearlo para obtenerlo. Ahora directamente lo que retorna la función es el state, de forma similar a lo que se hace en el login con el code.

## Tests

Se actualizaron los tests para que se adapten a este cambio.

