### PR TITLE
Added resetSDK to configuration module

### DIFF
--- a/sdk/configuration/__tests__/index.test.js
+++ b/sdk/configuration/__tests__/index.test.js
@@ -23,6 +23,7 @@ describe('configuration module', () => {
     const parameters2 = {
       redirectUri: 'redirectUri',
       clientSecret: 'clientSecret',
+      postLogoutRedirectUri: 'postLogoutRedirectUri',
     };
     const parameters3 = {
       clientId: 'clientId',
@@ -52,7 +53,7 @@ describe('configuration module', () => {
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      postLogoutRedirectUri: '',
+      postLogoutRedirectUri: 'postLogoutRedirectUri',
       state: '',
     });
     setParameters(parameters3);
@@ -66,7 +67,7 @@ describe('configuration module', () => {
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      postLogoutRedirectUri: '',
+      postLogoutRedirectUri: 'postLogoutRedirectUri',
       state: '',
     });
     setParameters(parameters4);
@@ -80,7 +81,7 @@ describe('configuration module', () => {
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      postLogoutRedirectUri: '',
+      postLogoutRedirectUri: 'postLogoutRedirectUri',
       state: '',
     });
     setParameters(parameters5);
@@ -94,7 +95,7 @@ describe('configuration module', () => {
       tokenType: 'tokenType',
       expiresIn: 'expiresIn',
       idToken: 'idToken',
-      postLogoutRedirectUri: '',
+      postLogoutRedirectUri: 'postLogoutRedirectUri',
       state: '',
     });
     clearParameters();
@@ -108,7 +109,7 @@ describe('configuration module', () => {
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      postLogoutRedirectUri: '',
+      postLogoutRedirectUri: 'postLogoutRedirectUri',
       state: '',
     });
     resetParameters();

--- a/sdk/configuration/__tests__/index.test.js
+++ b/sdk/configuration/__tests__/index.test.js
@@ -1,4 +1,9 @@
-import { getParameters, setParameters, clearParameters } from '../index';
+import {
+  getParameters,
+  setParameters,
+  clearParameters,
+  resetParameters,
+} from '../index';
 
 describe('configuration module', () => {
   it('works correctly', () => {
@@ -97,6 +102,20 @@ describe('configuration module', () => {
       redirectUri: 'redirectUri',
       clientId: 'clientId2',
       clientSecret: 'clientSecret',
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      postLogoutRedirectUri: '',
+      state: '',
+    });
+    resetParameters();
+    expect(getParameters()).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
       code: '',
       accessToken: '',
       refreshToken: '',

--- a/sdk/configuration/index.js
+++ b/sdk/configuration/index.js
@@ -32,4 +32,10 @@ const clearParameters = () => {
   });
 };
 
-export { getParameters, setParameters, clearParameters };
+const resetSDK = () => {
+  Object.keys(parameters).forEach(key => {
+    parameters[key] = '';
+  });
+};
+
+export { getParameters, setParameters, clearParameters, resetSDK };

--- a/sdk/configuration/index.js
+++ b/sdk/configuration/index.js
@@ -32,10 +32,10 @@ const clearParameters = () => {
   });
 };
 
-const resetSDK = () => {
+const resetParameters = () => {
   Object.keys(parameters).forEach(key => {
     parameters[key] = '';
   });
 };
 
-export { getParameters, setParameters, clearParameters, resetSDK };
+export { getParameters, setParameters, clearParameters, resetParameters };

--- a/sdk/index.js
+++ b/sdk/index.js
@@ -7,7 +7,7 @@ import {
   getUserInfo,
   refreshToken,
 } from './interfaces';
-import { getParameters, setParameters } from './configuration';
+import { getParameters, setParameters, resetParameters } from './configuration';
 
 export {
   initialize,
@@ -18,4 +18,5 @@ export {
   refreshToken,
   logout,
   setParameters,
+  resetParameters,
 };


### PR DESCRIPTION
# feature/resetSDK

## Descripción

Se implementó la función resetParameters al módulo de configuración. Esta función permite limpiar por completo los parámetros del SDK, incluyendo el clientId, clientSecret, redirectUri, y postLogoutRedirectUri, los cuales no son seteados a vacío por la función clearParameters.

## Tests

- [x] Se testea la función en el módulo de tests de configuración.

