### PR TITLE
Catch error in getUserInfo when idToken is incorrectly encoded

### DIFF
--- a/sdk/__tests__/interfaces-integration/getUserInfo.test.js
+++ b/sdk/__tests__/interfaces-integration/getUserInfo.test.js
@@ -32,15 +32,269 @@ beforeEach(() => {
 
 const contentType = 'application/x-www-form-urlencoded;charset=UTF-8';
 const accept = 'application/json';
-const accessToken = 'c9747e3173544b7b870d48aeafa0f661';
+const accessToken = 'accessToken';
 const userInfoEndpoint =
   'https://auth-testing.iduruguay.gub.uy/oidc/v1/userinfo';
+const userInfoProductionEndpoint =
+  'https://auth.iduruguay.gub.uy/oidc/v1/userinfo';
 const userId = 'uy-cid-12345678';
 const idToken =
   'eyJhbGciOiJSUzI1NiIsImtpZCI6IjdhYThlN2YzOTE2ZGNiM2YyYTUxMWQzY2ZiMTk4YmY0In0.eyJpc3MiOiJodHRwczovL2F1dGgtdGVzdGluZy5pZHVydWd1YXkuZ3ViLnV5L29pZGMvdjEiLCJzdWIiOiI1ODU5IiwiYXVkIjoiODk0MzI5IiwiZXhwIjoxNjAxNTA2Nzc5LCJpYXQiOjE2MDE1MDYxNzksImF1dGhfdGltZSI6MTYwMTUwMTA0OSwiYW1yIjpbInVybjppZHVydWd1YXk6YW06cGFzc3dvcmQiXSwiYWNyIjoidXJuOmlkdXJ1Z3VheTpuaWQ6MSIsImF0X2hhc2giOiJmZ1pFMG1DYml2ZmxBcV95NWRTT09RIn0.r2kRakfFjIXBSWlvAqY-hh9A5Em4n5SWIn9Dr0IkVvnikoAh_E1OPg1o0IT1RW-0qIt0rfkoPUDCCPNrl6d_uNwabsDV0r2LgBSAhjFIQigM37H1buCAn6A5kiUNh8h_zxKxwA8qqia7tql9PUYwNkgslAjgCKR79imMz4j53iw';
 
-describe('configuration module and get user info integration', () => {
-  it('calls set parameters and get user info with all scopes', async () => {
+const validFetchMockImplementation = () =>
+  Promise.resolve({
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        sub: mockSub,
+      }),
+  });
+
+describe('configuration & security modules and get user info integration', () => {
+  it('calls set parameters and get user info (no scope claims)', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken,
+      code,
+      redirectUri,
+      idToken,
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      state: '',
+      scope: '',
+    });
+
+    fetch.mockImplementation(validFetchMockImplementation);
+
+    const response = await getUserInfo();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(userInfoEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      sslPinning: {
+        certs: ['certificate'],
+      },
+      headers: {
+        Authorization: `Bearer ${parameters.accessToken}`,
+        'Content-Type': contentType,
+        Accept: accept,
+      },
+    });
+
+    expect(response).toStrictEqual({
+      message: ERRORS.NO_ERROR,
+      errorCode: ERRORS.NO_ERROR.errorCode,
+      errorDescription: ERRORS.NO_ERROR.errorDescription,
+      sub: mockSub,
+    });
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      state: '',
+      scope: '',
+    });
+  });
+
+  it('calls set parameters and get user info with production set to true', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    const production = true;
+
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken,
+      code,
+      redirectUri,
+      idToken,
+      production,
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      state: '',
+      scope: '',
+    });
+
+    fetch.mockImplementation(validFetchMockImplementation);
+
+    const response = await getUserInfo();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(userInfoProductionEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      sslPinning: {
+        certs: ['certificate'],
+      },
+      headers: {
+        Authorization: `Bearer ${parameters.accessToken}`,
+        'Content-Type': contentType,
+        Accept: accept,
+      },
+    });
+
+    expect(response).toStrictEqual({
+      message: ERRORS.NO_ERROR,
+      errorCode: ERRORS.NO_ERROR.errorCode,
+      errorDescription: ERRORS.NO_ERROR.errorDescription,
+      sub: mockSub,
+    });
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      state: '',
+      scope: '',
+    });
+  });
+
+  it('calls set parameters and get user info (one scope claims)', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    const scope = 'personal_info';
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken,
+      code,
+      redirectUri,
+      idToken,
+      scope,
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      state: '',
+      scope,
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            nombre_completo: 'test',
+            primer_apellido: 'test',
+            primer_nombre: 'testNombre',
+            segundo_apellido: 'testApellido',
+            segundo_nombre: 'testSegundoNombre',
+            sub: mockSub,
+            uid: userId,
+            rid: 'rid',
+          }),
+      }),
+    );
+
+    const response = await getUserInfo();
+
+    expect(fetch).toHaveBeenCalledWith(userInfoEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      sslPinning: {
+        certs: ['certificate'],
+      },
+      headers: {
+        Authorization: `Bearer ${parameters.accessToken}`,
+        'Content-Type': contentType,
+        Accept: accept,
+      },
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(response).toStrictEqual({
+      message: ERRORS.NO_ERROR,
+      errorCode: ERRORS.NO_ERROR.errorCode,
+      errorDescription: ERRORS.NO_ERROR.errorDescription,
+      nombre_completo: 'test',
+      primer_apellido: 'test',
+      primer_nombre: 'testNombre',
+      segundo_apellido: 'testApellido',
+      segundo_nombre: 'testSegundoNombre',
+      sub: mockSub,
+      uid: userId,
+      rid: 'rid',
+    });
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      state: '',
+      scope,
+    });
+  });
+
+  it('calls set parameters and get user info (all scopes claims)', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -156,103 +410,7 @@ describe('configuration module and get user info integration', () => {
     });
   });
 
-  it('calls set parameters and get user info with personal_info scope', async () => {
-    const clientId = 'clientId';
-    const clientSecret = 'clientSecret';
-    const code = 'correctCode';
-    const redirectUri = 'redirectUri';
-    const scope = 'personal_info';
-    setParameters({
-      clientId,
-      clientSecret,
-      accessToken,
-      code,
-      redirectUri,
-      idToken,
-      scope,
-    });
-
-    let parameters = getParameters();
-    expect(parameters).toStrictEqual({
-      redirectUri,
-      clientId,
-      clientSecret,
-      production: false,
-      code,
-      accessToken,
-      refreshToken: '',
-      tokenType: '',
-      expiresIn: '',
-      idToken,
-      state: '',
-      scope,
-    });
-
-    fetch.mockImplementation(() =>
-      Promise.resolve({
-        status: 200,
-        json: () =>
-          Promise.resolve({
-            nombre_completo: 'test',
-            primer_apellido: 'test',
-            primer_nombre: 'testNombre',
-            segundo_apellido: 'testApellido',
-            segundo_nombre: 'testSegundoNombre',
-            sub: mockSub,
-            uid: userId,
-            rid: 'rid',
-          }),
-      }),
-    );
-
-    const response = await getUserInfo();
-
-    expect(fetch).toHaveBeenCalledWith(userInfoEndpoint, {
-      method: 'GET',
-      pkPinning: Platform.OS === 'ios',
-      sslPinning: {
-        certs: ['certificate'],
-      },
-      headers: {
-        Authorization: `Bearer ${parameters.accessToken}`,
-        'Content-Type': contentType,
-        Accept: accept,
-      },
-    });
-
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(response).toStrictEqual({
-      message: ERRORS.NO_ERROR,
-      errorCode: ERRORS.NO_ERROR.errorCode,
-      errorDescription: ERRORS.NO_ERROR.errorDescription,
-      nombre_completo: 'test',
-      primer_apellido: 'test',
-      primer_nombre: 'testNombre',
-      segundo_apellido: 'testApellido',
-      segundo_nombre: 'testSegundoNombre',
-      sub: mockSub,
-      uid: userId,
-      rid: 'rid',
-    });
-
-    parameters = getParameters();
-    expect(parameters).toStrictEqual({
-      redirectUri,
-      clientId,
-      clientSecret,
-      production: false,
-      code,
-      accessToken,
-      refreshToken: '',
-      tokenType: '',
-      expiresIn: '',
-      idToken,
-      state: '',
-      scope,
-    });
-  });
-
-  it('calls set parameters and get user info with no claims', async () => {
+  it('calls set parameters and get user info with empty accessToken', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -260,7 +418,7 @@ describe('configuration module and get user info integration', () => {
     setParameters({
       clientId,
       clientSecret,
-      accessToken,
+      accessToken: '',
       code,
       redirectUri,
       idToken,
@@ -273,7 +431,7 @@ describe('configuration module and get user info integration', () => {
       clientSecret,
       production: false,
       code,
-      accessToken,
+      accessToken: '',
       refreshToken: '',
       tokenType: '',
       expiresIn: '',
@@ -281,40 +439,11 @@ describe('configuration module and get user info integration', () => {
       state: '',
       scope: '',
     });
-
-    fetch.mockImplementation(() =>
-      Promise.resolve({
-        status: 200,
-        json: () =>
-          Promise.resolve({
-            sub: mockSub,
-          }),
-      }),
-    );
-
-    const response = await getUserInfo();
-
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith(userInfoEndpoint, {
-      method: 'GET',
-      pkPinning: Platform.OS === 'ios',
-      sslPinning: {
-        certs: ['certificate'],
-      },
-      headers: {
-        Authorization: `Bearer ${parameters.accessToken}`,
-        'Content-Type': contentType,
-        Accept: accept,
-      },
-    });
-
-    expect(response).toStrictEqual({
-      message: ERRORS.NO_ERROR,
-      errorCode: ERRORS.NO_ERROR.errorCode,
-      errorDescription: ERRORS.NO_ERROR.errorDescription,
-      sub: mockSub,
-    });
-
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_TOKEN);
+    }
     parameters = getParameters();
     expect(parameters).toStrictEqual({
       redirectUri,
@@ -322,7 +451,7 @@ describe('configuration module and get user info integration', () => {
       clientSecret,
       production: false,
       code,
-      accessToken,
+      accessToken: '',
       refreshToken: '',
       tokenType: '',
       expiresIn: '',
@@ -330,9 +459,240 @@ describe('configuration module and get user info integration', () => {
       state: '',
       scope: '',
     });
+    expect.assertions(3);
   });
 
-  it('calls set parameters and get user info with expired access token', async () => {
+  it('calls set parameters and get user info with empty idToken', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken,
+      code,
+      redirectUri,
+      idToken: '',
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      code,
+      accessToken,
+      production: false,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_ID_TOKEN);
+    }
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      code,
+      production: false,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+    expect.assertions(3);
+  });
+
+  it('calls set parameters and get user info with invalid accessToken', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+
+    try {
+      setParameters({
+        clientId,
+        clientSecret,
+        accessToken: 'invalid_access_token',
+        code,
+        redirectUri,
+        idToken,
+      });
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_TOKEN);
+    }
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_TOKEN);
+    }
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+    expect.assertions(4);
+  });
+
+  it('calls set parameters and get user info with invalid idToken', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+
+    try {
+      setParameters({
+        clientId,
+        clientSecret,
+        accessToken,
+        code,
+        redirectUri,
+        idToken: 'invalid_id_token',
+      });
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN);
+    }
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_TOKEN);
+    }
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+    expect.assertions(4);
+  });
+
+  it('calls set parameters and get user info with invalid production', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+
+    try {
+      setParameters({
+        clientId,
+        clientSecret,
+        accessToken,
+        code,
+        redirectUri,
+        idToken,
+        production: 'invalid_production',
+      });
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_PRODUCTION);
+    }
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_TOKEN);
+    }
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+    expect.assertions(4);
+  });
+
+  it('calls set parameters and get user info with expired accessToken', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -453,7 +813,7 @@ describe('configuration module and get user info integration', () => {
     expect.assertions(3);
   });
 
-  it('calls set parameters and get user info, returns some error', async () => {
+  it('calls set parameters and get user info, fetch returns some error', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -513,7 +873,7 @@ describe('configuration module and get user info integration', () => {
     expect.assertions(3);
   });
 
-  it('calls set parameters and get user info, returns some error with www authenticate header', async () => {
+  it('calls set parameters and get user info, fetch returns some error with www authenticate header', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -567,110 +927,6 @@ describe('configuration module and get user info integration', () => {
       tokenType: '',
       expiresIn: '',
       idToken,
-      state: '',
-      scope: '',
-    });
-    expect.assertions(3);
-  });
-
-  it('calls set parameters and get user info with empty access token', async () => {
-    const clientId = 'clientId';
-    const clientSecret = 'clientSecret';
-    const code = 'correctCode';
-    const redirectUri = 'redirectUri';
-    setParameters({
-      clientId,
-      clientSecret,
-      accessToken: '',
-      code,
-      redirectUri,
-      idToken,
-    });
-
-    let parameters = getParameters();
-    expect(parameters).toStrictEqual({
-      redirectUri,
-      clientId,
-      clientSecret,
-      production: false,
-      code,
-      accessToken: '',
-      refreshToken: '',
-      tokenType: '',
-      expiresIn: '',
-      idToken,
-      state: '',
-      scope: '',
-    });
-    try {
-      await getUserInfo();
-    } catch (err) {
-      expect(err).toBe(ERRORS.INVALID_TOKEN);
-    }
-    parameters = getParameters();
-    expect(parameters).toStrictEqual({
-      redirectUri,
-      clientId,
-      clientSecret,
-      production: false,
-      code,
-      accessToken: '',
-      refreshToken: '',
-      tokenType: '',
-      expiresIn: '',
-      idToken,
-      state: '',
-      scope: '',
-    });
-    expect.assertions(3);
-  });
-
-  it('calls getUserInfo with empty id token', async () => {
-    const clientId = 'clienttt';
-    const clientSecret = 'secrettest';
-    const code = 'test';
-    const redirectUri = 'redirecttesturi';
-    setParameters({
-      clientId,
-      clientSecret,
-      accessToken,
-      code,
-      redirectUri,
-      idToken: '',
-    });
-
-    let parameters = getParameters();
-    expect(parameters).toStrictEqual({
-      redirectUri,
-      clientId,
-      clientSecret,
-      code,
-      accessToken,
-      production: false,
-      refreshToken: '',
-      tokenType: '',
-      expiresIn: '',
-      idToken: '',
-      state: '',
-      scope: '',
-    });
-    try {
-      await getUserInfo();
-    } catch (err) {
-      expect(err).toBe(ERRORS.INVALID_ID_TOKEN);
-    }
-    parameters = getParameters();
-    expect(parameters).toStrictEqual({
-      redirectUri,
-      clientId,
-      clientSecret,
-      code,
-      production: false,
-      accessToken,
-      refreshToken: '',
-      tokenType: '',
-      expiresIn: '',
-      idToken: '',
       state: '',
       scope: '',
     });

--- a/sdk/__tests__/requests-integration/getUserInfo.test.js
+++ b/sdk/__tests__/requests-integration/getUserInfo.test.js
@@ -50,7 +50,7 @@ const validFetchMockImplementation = () =>
       }),
   });
 
-describe('configuration & security modules make request type get user info integration', () => {
+describe('configuration & security modules and make request type get user info integration', () => {
   it('calls set parameters and makes a get user info request (no scope claims)', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';

--- a/sdk/__tests__/requests-integration/getUserInfo.test.js
+++ b/sdk/__tests__/requests-integration/getUserInfo.test.js
@@ -39,8 +39,7 @@ const userInfoEndpoint =
 const userInfoProductionEndpoint =
   'https://auth.iduruguay.gub.uy/oidc/v1/userinfo';
 const userId = 'uy-cid-12345678';
-const idToken =
-  'eyJhbGciOiJSUzI1NiIsImtpZCI6IjdhYThlN2YzOTE2ZGNiM2YyYTUxMWQzY2ZiMTk4YmY0In0.eyJpc3MiOiJodHRwczovL2F1dGgtdGVzdGluZy5pZHVydWd1YXkuZ3ViLnV5L29pZGMvdjEiLCJzdWIiOiI1ODU5IiwiYXVkIjoiODk0MzI5IiwiZXhwIjoxNjAxNTA2Nzc5LCJpYXQiOjE2MDE1MDYxNzksImF1dGhfdGltZSI6MTYwMTUwMTA0OSwiYW1yIjpbInVybjppZHVydWd1YXk6YW06cGFzc3dvcmQiXSwiYWNyIjoidXJuOmlkdXJ1Z3VheTpuaWQ6MSIsImF0X2hhc2giOiJmZ1pFMG1DYml2ZmxBcV95NWRTT09RIn0.r2kRakfFjIXBSWlvAqY-hh9A5Em4n5SWIn9Dr0IkVvnikoAh_E1OPg1o0IT1RW-0qIt0rfkoPUDCCPNrl6d_uNwabsDV0r2LgBSAhjFIQigM37H1buCAn6A5kiUNh8h_zxKxwA8qqia7tql9PUYwNkgslAjgCKR79imMz4j53iw';
+const idToken = 'valid.id.token';
 
 const validFetchMockImplementation = () =>
   Promise.resolve({
@@ -631,6 +630,76 @@ describe('configuration & security modules and make request type get user info i
       scope: '',
     });
     expect.assertions(4);
+  });
+
+  it('calls set parameters and makes a get user info request with incorrectly encoded idToken', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken,
+      code,
+      redirectUri,
+      idToken: 'id.token',
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: 'id.token',
+      state: '',
+      scope: '',
+    });
+
+    fetch.mockImplementation(validFetchMockImplementation);
+
+    try {
+      await makeRequest(REQUEST_TYPES.GET_USER_INFO);
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN);
+    }
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(userInfoEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      sslPinning: {
+        certs: ['certificate'],
+      },
+      headers: {
+        Authorization: `Bearer ${parameters.accessToken}`,
+        'Content-Type': contentType,
+        Accept: accept,
+      },
+    });
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: 'id.token',
+      state: '',
+      scope: '',
+    });
+    expect.assertions(5);
   });
 
   it('calls set parameters and makes a get user info request with invalid production', async () => {

--- a/sdk/__tests__/requests-integration/getUserInfo.test.js
+++ b/sdk/__tests__/requests-integration/getUserInfo.test.js
@@ -33,20 +33,30 @@ beforeEach(() => {
 
 const contentType = 'application/x-www-form-urlencoded;charset=UTF-8';
 const accept = 'application/json';
-const accessToken = 'c9747e3173544b7b870d48aeafa0f661';
+const accessToken = 'accessToken';
 const userInfoEndpoint =
   'https://auth-testing.iduruguay.gub.uy/oidc/v1/userinfo';
+const userInfoProductionEndpoint =
+  'https://auth.iduruguay.gub.uy/oidc/v1/userinfo';
 const userId = 'uy-cid-12345678';
 const idToken =
   'eyJhbGciOiJSUzI1NiIsImtpZCI6IjdhYThlN2YzOTE2ZGNiM2YyYTUxMWQzY2ZiMTk4YmY0In0.eyJpc3MiOiJodHRwczovL2F1dGgtdGVzdGluZy5pZHVydWd1YXkuZ3ViLnV5L29pZGMvdjEiLCJzdWIiOiI1ODU5IiwiYXVkIjoiODk0MzI5IiwiZXhwIjoxNjAxNTA2Nzc5LCJpYXQiOjE2MDE1MDYxNzksImF1dGhfdGltZSI6MTYwMTUwMTA0OSwiYW1yIjpbInVybjppZHVydWd1YXk6YW06cGFzc3dvcmQiXSwiYWNyIjoidXJuOmlkdXJ1Z3VheTpuaWQ6MSIsImF0X2hhc2giOiJmZ1pFMG1DYml2ZmxBcV95NWRTT09RIn0.r2kRakfFjIXBSWlvAqY-hh9A5Em4n5SWIn9Dr0IkVvnikoAh_E1OPg1o0IT1RW-0qIt0rfkoPUDCCPNrl6d_uNwabsDV0r2LgBSAhjFIQigM37H1buCAn6A5kiUNh8h_zxKxwA8qqia7tql9PUYwNkgslAjgCKR79imMz4j53iw';
 
-describe('configuration module and make request type get user info integration', () => {
-  it('calls set parameters and makes a get user info request with all scopes', async () => {
+const validFetchMockImplementation = () =>
+  Promise.resolve({
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        sub: mockSub,
+      }),
+  });
+
+describe('configuration & security modules and make request type get user info integration', () => {
+  it('calls set parameters and makes a get user info request (no scope claims)', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
     const redirectUri = 'redirectUri';
-    const scope = 'personal_info%20profile%20document%20email%20auth_info';
     setParameters({
       clientId,
       clientSecret,
@@ -54,7 +64,6 @@ describe('configuration module and make request type get user info integration',
       code,
       redirectUri,
       idToken,
-      scope,
     });
 
     let parameters = getParameters();
@@ -70,38 +79,14 @@ describe('configuration module and make request type get user info integration',
       expiresIn: '',
       idToken,
       state: '',
-      scope,
+      scope: '',
     });
 
-    fetch.mockImplementation(() =>
-      Promise.resolve({
-        status: 200,
-        json: () =>
-          Promise.resolve({
-            nombre_completo: 'test',
-            primer_apellido: 'test',
-            primer_nombre: 'testNombre',
-            segundo_apellido: 'testApellido',
-            segundo_nombre: 'testSegundoNombre',
-            sub: mockSub,
-            uid: userId,
-            name: 'name',
-            given_name: 'given_name',
-            family_name: 'family_name',
-            pais_documento: 'pais_documento',
-            tipo_documento: 'tipo_documento',
-            numero_documento: 'numero_documento',
-            email: 'email',
-            email_verified: 'email_verified',
-            rid: 'rid',
-            nid: 'nid',
-            ae: 'ae',
-          }),
-      }),
-    );
+    fetch.mockImplementation(validFetchMockImplementation);
 
     const response = await makeRequest(REQUEST_TYPES.GET_USER_INFO);
 
+    expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(userInfoEndpoint, {
       method: 'GET',
       pkPinning: Platform.OS === 'ios',
@@ -115,29 +100,11 @@ describe('configuration module and make request type get user info integration',
       },
     });
 
-    expect(fetch).toHaveBeenCalledTimes(1);
     expect(response).toStrictEqual({
       message: ERRORS.NO_ERROR,
       errorCode: ERRORS.NO_ERROR.errorCode,
       errorDescription: ERRORS.NO_ERROR.errorDescription,
-      nombre_completo: 'test',
-      primer_apellido: 'test',
-      primer_nombre: 'testNombre',
-      segundo_apellido: 'testApellido',
-      segundo_nombre: 'testSegundoNombre',
       sub: mockSub,
-      uid: userId,
-      name: 'name',
-      given_name: 'given_name',
-      family_name: 'family_name',
-      pais_documento: 'pais_documento',
-      tipo_documento: 'tipo_documento',
-      numero_documento: 'numero_documento',
-      email: 'email',
-      email_verified: 'email_verified',
-      rid: 'rid',
-      nid: 'nid',
-      ae: 'ae',
     });
 
     parameters = getParameters();
@@ -153,11 +120,86 @@ describe('configuration module and make request type get user info integration',
       expiresIn: '',
       idToken,
       state: '',
-      scope,
+      scope: '',
     });
   });
 
-  it('calls set parameters and makes a get user info request with personal_info scope', async () => {
+  it('calls set parameters and makes a get user info request with production set to true', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    const production = true;
+
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken,
+      code,
+      redirectUri,
+      idToken,
+      production,
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      state: '',
+      scope: '',
+    });
+
+    fetch.mockImplementation(validFetchMockImplementation);
+
+    const response = await makeRequest(REQUEST_TYPES.GET_USER_INFO);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(userInfoProductionEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      sslPinning: {
+        certs: ['certificate'],
+      },
+      headers: {
+        Authorization: `Bearer ${parameters.accessToken}`,
+        'Content-Type': contentType,
+        Accept: accept,
+      },
+    });
+
+    expect(response).toStrictEqual({
+      message: ERRORS.NO_ERROR,
+      errorCode: ERRORS.NO_ERROR.errorCode,
+      errorDescription: ERRORS.NO_ERROR.errorDescription,
+      sub: mockSub,
+    });
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      state: '',
+      scope: '',
+    });
+  });
+
+  it('calls set parameters and makes a get user info request (one scope claims)', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -253,11 +295,12 @@ describe('configuration module and make request type get user info integration',
     });
   });
 
-  it('calls set parameters and makes a get user info request with no claims', async () => {
+  it('calls set parameters and makes a get user info request (all scopes claims)', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
     const redirectUri = 'redirectUri';
+    const scope = 'personal_info%20profile%20document%20email%20auth_info';
     setParameters({
       clientId,
       clientSecret,
@@ -265,6 +308,7 @@ describe('configuration module and make request type get user info integration',
       code,
       redirectUri,
       idToken,
+      scope,
     });
 
     let parameters = getParameters();
@@ -275,12 +319,12 @@ describe('configuration module and make request type get user info integration',
       production: false,
       code,
       accessToken,
+      idToken,
       refreshToken: '',
       tokenType: '',
       expiresIn: '',
-      idToken,
       state: '',
-      scope: '',
+      scope,
     });
 
     fetch.mockImplementation(() =>
@@ -288,14 +332,30 @@ describe('configuration module and make request type get user info integration',
         status: 200,
         json: () =>
           Promise.resolve({
+            nombre_completo: 'test',
+            primer_apellido: 'test',
+            primer_nombre: 'testNombre',
+            segundo_apellido: 'testApellido',
+            segundo_nombre: 'testSegundoNombre',
             sub: mockSub,
+            uid: userId,
+            name: 'name',
+            given_name: 'given_name',
+            family_name: 'family_name',
+            pais_documento: 'pais_documento',
+            tipo_documento: 'tipo_documento',
+            numero_documento: 'numero_documento',
+            email: 'email',
+            email_verified: 'email_verified',
+            rid: 'rid',
+            nid: 'nid',
+            ae: 'ae',
           }),
       }),
     );
 
     const response = await makeRequest(REQUEST_TYPES.GET_USER_INFO);
 
-    expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(userInfoEndpoint, {
       method: 'GET',
       pkPinning: Platform.OS === 'ios',
@@ -309,11 +369,29 @@ describe('configuration module and make request type get user info integration',
       },
     });
 
+    expect(fetch).toHaveBeenCalledTimes(1);
     expect(response).toStrictEqual({
       message: ERRORS.NO_ERROR,
       errorCode: ERRORS.NO_ERROR.errorCode,
       errorDescription: ERRORS.NO_ERROR.errorDescription,
+      nombre_completo: 'test',
+      primer_apellido: 'test',
+      primer_nombre: 'testNombre',
+      segundo_apellido: 'testApellido',
+      segundo_nombre: 'testSegundoNombre',
       sub: mockSub,
+      uid: userId,
+      name: 'name',
+      given_name: 'given_name',
+      family_name: 'family_name',
+      pais_documento: 'pais_documento',
+      tipo_documento: 'tipo_documento',
+      numero_documento: 'numero_documento',
+      email: 'email',
+      email_verified: 'email_verified',
+      rid: 'rid',
+      nid: 'nid',
+      ae: 'ae',
     });
 
     parameters = getParameters();
@@ -329,11 +407,293 @@ describe('configuration module and make request type get user info integration',
       expiresIn: '',
       idToken,
       state: '',
-      scope: '',
+      scope,
     });
   });
 
-  it('calls set parameters and makes a get user info request with expired access token', async () => {
+  it('calls set parameters and makes a get user info request with empty accessToken', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken: '',
+      code,
+      redirectUri,
+      idToken,
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      state: '',
+      scope: '',
+    });
+    try {
+      await makeRequest(REQUEST_TYPES.GET_USER_INFO);
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_TOKEN);
+    }
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      state: '',
+      scope: '',
+    });
+    expect.assertions(3);
+  });
+
+  it('calls set parameters and makes a get user info request with empty idToken', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken,
+      code,
+      redirectUri,
+      idToken: '',
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      code,
+      accessToken,
+      production: false,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+    try {
+      await makeRequest(REQUEST_TYPES.GET_USER_INFO);
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_ID_TOKEN);
+    }
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      code,
+      production: false,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+    expect.assertions(3);
+  });
+
+  it('calls set parameters and makes a get user info request with invalid accessToken', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+
+    try {
+      setParameters({
+        clientId,
+        clientSecret,
+        accessToken: 'invalid_access_token',
+        code,
+        redirectUri,
+        idToken,
+      });
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_TOKEN);
+    }
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+
+    try {
+      await makeRequest(REQUEST_TYPES.GET_USER_INFO);
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_TOKEN);
+    }
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+    expect.assertions(4);
+  });
+
+  it('calls set parameters and makes a get user info request with invalid idToken', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+
+    try {
+      setParameters({
+        clientId,
+        clientSecret,
+        accessToken,
+        code,
+        redirectUri,
+        idToken: 'invalid_id_token',
+      });
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN);
+    }
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+
+    try {
+      await makeRequest(REQUEST_TYPES.GET_USER_INFO);
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_TOKEN);
+    }
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+    expect.assertions(4);
+  });
+
+  it('calls set parameters and makes a get user info request with invalid production', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+
+    try {
+      setParameters({
+        clientId,
+        clientSecret,
+        accessToken,
+        code,
+        redirectUri,
+        idToken,
+        production: 'invalid_production',
+      });
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_PRODUCTION);
+    }
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+
+    try {
+      await makeRequest(REQUEST_TYPES.GET_USER_INFO);
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_TOKEN);
+    }
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      state: '',
+      scope: '',
+    });
+    expect.assertions(4);
+  });
+
+  it('calls set parameters and makes a get user info request with expired accessToken', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -396,7 +756,7 @@ describe('configuration module and make request type get user info integration',
     expect.assertions(3);
   });
 
-  it('calls set parameters, makes a get user info request and fetch fails', async () => {
+  it('calls set parameters and makes a get user info request, fetch fails', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -454,7 +814,7 @@ describe('configuration module and make request type get user info integration',
     expect.assertions(3);
   });
 
-  it('calls set parameters, makes a get user info request and returns some error', async () => {
+  it('calls set parameters and makes a get user info request, fetch returns some error', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -514,7 +874,7 @@ describe('configuration module and make request type get user info integration',
     expect.assertions(3);
   });
 
-  it('calls set parameters, makes a get user info request and returns some error with www authenticate header', async () => {
+  it('calls set parameters and makes a get user info request, fetch returns some error with www authenticate header', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -568,110 +928,6 @@ describe('configuration module and make request type get user info integration',
       tokenType: '',
       expiresIn: '',
       idToken,
-      state: '',
-      scope: '',
-    });
-    expect.assertions(3);
-  });
-
-  it('calls set parameters and makes a get user info request with empty access token', async () => {
-    const clientId = 'clientId';
-    const clientSecret = 'clientSecret';
-    const code = 'correctCode';
-    const redirectUri = 'redirectUri';
-    setParameters({
-      clientId,
-      clientSecret,
-      accessToken: '',
-      code,
-      redirectUri,
-      idToken,
-    });
-
-    let parameters = getParameters();
-    expect(parameters).toStrictEqual({
-      redirectUri,
-      clientId,
-      clientSecret,
-      production: false,
-      code,
-      accessToken: '',
-      refreshToken: '',
-      tokenType: '',
-      expiresIn: '',
-      idToken,
-      state: '',
-      scope: '',
-    });
-    try {
-      await makeRequest(REQUEST_TYPES.GET_USER_INFO);
-    } catch (err) {
-      expect(err).toBe(ERRORS.INVALID_TOKEN);
-    }
-    parameters = getParameters();
-    expect(parameters).toStrictEqual({
-      redirectUri,
-      clientId,
-      clientSecret,
-      production: false,
-      code,
-      accessToken: '',
-      refreshToken: '',
-      tokenType: '',
-      expiresIn: '',
-      idToken,
-      state: '',
-      scope: '',
-    });
-    expect.assertions(3);
-  });
-
-  it('calls set parameters and makes a getUserInfo request with empty id token', async () => {
-    const clientId = 'clientId';
-    const clientSecret = 'clientSecret';
-    const code = 'correctCode';
-    const redirectUri = 'redirectUri';
-    setParameters({
-      clientId,
-      clientSecret,
-      accessToken,
-      code,
-      redirectUri,
-      idToken: '',
-    });
-
-    let parameters = getParameters();
-    expect(parameters).toStrictEqual({
-      redirectUri,
-      clientId,
-      clientSecret,
-      code,
-      accessToken,
-      production: false,
-      refreshToken: '',
-      tokenType: '',
-      expiresIn: '',
-      idToken: '',
-      state: '',
-      scope: '',
-    });
-    try {
-      await makeRequest(REQUEST_TYPES.GET_USER_INFO);
-    } catch (err) {
-      expect(err).toBe(ERRORS.INVALID_ID_TOKEN);
-    }
-    parameters = getParameters();
-    expect(parameters).toStrictEqual({
-      redirectUri,
-      clientId,
-      clientSecret,
-      code,
-      production: false,
-      accessToken,
-      refreshToken: '',
-      tokenType: '',
-      expiresIn: '',
-      idToken: '',
       state: '',
       scope: '',
     });

--- a/sdk/requests/__tests__/getUserInfo.test.js
+++ b/sdk/requests/__tests__/getUserInfo.test.js
@@ -21,8 +21,7 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-const idToken =
-  'eyJhbGciOiJSUzI1NiIsImtpZCI6IjdhYThlN2YzOTE2ZGNiM2YyYTUxMWQzY2ZiMTk4YmY0In0.eyJpc3MiOiJodHRwczovL2F1dGgtdGVzdGluZy5pZHVydWd1YXkuZ3ViLnV5L29pZGMvdjEiLCJzdWIiOiI1ODU5IiwiYXVkIjoiODk0MzI5IiwiZXhwIjoxNjAxNTA2Nzc5LCJpYXQiOjE2MDE1MDYxNzksImF1dGhfdGltZSI6MTYwMTUwMTA0OSwiYW1yIjpbInVybjppZHVydWd1YXk6YW06cGFzc3dvcmQiXSwiYWNyIjoidXJuOmlkdXJ1Z3VheTpuaWQ6MSIsImF0X2hhc2giOiJmZ1pFMG1DYml2ZmxBcV95NWRTT09RIn0.r2kRakfFjIXBSWlvAqY-hh9A5Em4n5SWIn9Dr0IkVvnikoAh_E1OPg1o0IT1RW-0qIt0rfkoPUDCCPNrl6d_uNwabsDV0r2LgBSAhjFIQigM37H1buCAn6A5kiUNh8h_zxKxwA8qqia7tql9PUYwNkgslAjgCKR79imMz4j53iw';
+const idToken = 'valid.id.token';
 
 describe('getUserInfo', () => {
   it('calls getUserInfo with correct accessToken', async () => {
@@ -232,51 +231,83 @@ describe('getUserInfo', () => {
     expect(validateSub).not.toHaveBeenCalled();
     expect.assertions(2);
   });
-});
 
-it('calls getUserInfo with empty Id Token', async () => {
-  const code = 'f24df0c4fcb142328b843d49753946af';
-  const redirectUri = 'uri';
-  getParameters.mockReturnValue({
-    clientId: '898562',
-    clientSecret: 'cdc04f19ac2s2f5h8f6we6d42b37e85a63f1w2e5f6sd8a4484b6b94b',
-    accessToken: 'correctAccessToken',
-    redirectUri,
-    code,
-    idToken: '',
+  it('calls getUserInfo with empty Id Token', async () => {
+    const code = 'f24df0c4fcb142328b843d49753946af';
+    const redirectUri = 'uri';
+    getParameters.mockReturnValue({
+      clientId: '898562',
+      clientSecret: 'cdc04f19ac2s2f5h8f6we6d42b37e85a63f1w2e5f6sd8a4484b6b94b',
+      accessToken: 'correctAccessToken',
+      redirectUri,
+      code,
+      idToken: '',
+    });
+
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_ID_TOKEN);
+    }
+
+    expect(validateSub).not.toHaveBeenCalled();
+    expect.assertions(2);
   });
 
-  try {
-    await getUserInfo();
-  } catch (err) {
-    expect(err).toBe(ERRORS.INVALID_ID_TOKEN);
-  }
+  it('calls getUserInfo and fetch fails', async () => {
+    getParameters.mockReturnValue({
+      clientId: 'clientId',
+      clientSecret: 'clientSecret',
+      redirectUri: 'redirectUri',
+      accessToken: 'accessToken',
+      idToken,
+    });
 
-  expect(validateSub).not.toHaveBeenCalled();
-  expect.assertions(2);
-});
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 400,
+        json: () => Promise.resolve(),
+      }),
+    );
 
-it('calls getUserInfo and fetch fails', async () => {
-  getParameters.mockReturnValue({
-    clientId: 'clientId',
-    clientSecret: 'clientSecret',
-    redirectUri: 'redirectUri',
-    accessToken: 'accessToken',
-    idToken,
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toStrictEqual(ERRORS.FAILED_REQUEST);
+    }
+    expect(validateSub).not.toHaveBeenCalled();
+    expect.assertions(2);
   });
 
-  fetch.mockImplementation(() =>
-    Promise.resolve({
-      status: 400,
-      json: () => Promise.resolve(),
-    }),
-  );
+  it('calls getUserInfo but idToken is incorrectly encoded', async () => {
+    validateSub.mockImplementation(() => {
+      throw ERRORS.INVALID_ID_TOKEN;
+    });
 
-  try {
-    await getUserInfo();
-  } catch (err) {
-    expect(err).toStrictEqual(ERRORS.FAILED_REQUEST);
-  }
-  expect(validateSub).not.toHaveBeenCalled();
-  expect.assertions(2);
+    getParameters.mockReturnValue({
+      clientId: 'clientId',
+      clientSecret: 'clientSecret',
+      accessToken: 'accessToken',
+      redirectUri: 'redirectUri',
+      code: 'correctCode',
+      idToken: 'id.token',
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            sub: 'sub',
+          }),
+      }),
+    );
+
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toBe(ERRORS.INVALID_ID_TOKEN);
+    }
+    expect.assertions(1);
+  });
 });

--- a/sdk/requests/getUserInfo.js
+++ b/sdk/requests/getUserInfo.js
@@ -53,7 +53,10 @@ const getUserInfo = async () => {
     }
     return Promise.reject(ERRORS.INVALID_SUB);
   } catch (error) {
-    const stringsHeaders = error.headers['Www-Authenticate'];
+    if (error === ERRORS.INVALID_ID_TOKEN) {
+      return Promise.reject(ERRORS.INVALID_ID_TOKEN);
+    }
+    const stringsHeaders = error.headers && error.headers['Www-Authenticate'];
     if (stringsHeaders && stringsHeaders.indexOf('invalid_token') !== -1)
       return Promise.reject(ERRORS.INVALID_TOKEN);
     return Promise.reject(ERRORS.FAILED_REQUEST);

--- a/sdk/security/__tests__/validateResponse.test.js
+++ b/sdk/security/__tests__/validateResponse.test.js
@@ -1,5 +1,6 @@
 import { generateRandomState, validateSub } from '../validateResponse';
 import { getParameters, setParameters } from '../../configuration';
+import ERRORS from '../../utils/errors';
 
 jest.mock('../../configuration');
 
@@ -58,5 +59,20 @@ describe('validateResponse', () => {
     const incorrectSub = '1234';
     const isValid = validateSub(incorrectSub);
     expect(isValid).toBe(false);
+  });
+
+  it('calls validate sub with incorrectly encoded idToken', async () => {
+    getParameters.mockReturnValue({
+      idToken: 'id.token',
+    });
+
+    const sub = '5859';
+
+    try {
+      validateSub(sub);
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN);
+    }
+    expect.assertions(1);
   });
 });

--- a/sdk/security/validateResponse.js
+++ b/sdk/security/validateResponse.js
@@ -4,6 +4,7 @@ import KJUR from 'jsrsasign';
 import { decode } from 'base-64';
 
 import { setParameters, getParameters } from '../configuration';
+import ERRORS from '../utils/errors';
 
 const isLetter = char => {
   const n = char.charCodeAt(0);
@@ -43,10 +44,14 @@ const generateRandomState = () => {
 // afirmativo y false en caso contrario.
 const validateSub = sub => {
   const { idToken } = getParameters();
-  const payloadObj = KJUR.jws.JWS.readSafeJSONString(
-    decode(idToken.split('.')[1]),
-  );
-  return payloadObj.sub === sub;
+  try {
+    const payloadObj = KJUR.jws.JWS.readSafeJSONString(
+      decode(idToken.split('.')[1]),
+    );
+    return payloadObj.sub === sub;
+  } catch (error) {
+    throw ERRORS.INVALID_ID_TOKEN;
+  }
 };
 
 export { generateRandomState, validateSub };


### PR DESCRIPTION
# PR Template

## Descripción

Corrección de error que producía un TypeError al pasarle un idToken mal formado a la función de validateSub.

## Tests

Se actualizaron todas las pruebas correspondientes.
