### PR TITLE
Cambio en descripcion de un error

### DIFF
--- a/sdk/__tests__/interfaces-integration/getUserInfo.test.js
+++ b/sdk/__tests__/interfaces-integration/getUserInfo.test.js
@@ -546,7 +546,7 @@ describe('configuration module and get user info integration', () => {
       Promise.reject({
         headers: {
           'Www-Authenticate':
-            'error="other_error", error_description="The access token provided is expired, revoked, malformed, or invalid for other reasons"',
+            'error="other_error", error_description="other_error_description"',
         },
       }),
     );

--- a/sdk/__tests__/requests-integration/getUserInfo.test.js
+++ b/sdk/__tests__/requests-integration/getUserInfo.test.js
@@ -547,7 +547,7 @@ describe('configuration module and make request type get user info integration',
       Promise.reject({
         headers: {
           'Www-Authenticate':
-            'error="other_error", error_description="The access token provided is expired, revoked, malformed, or invalid for other reasons"',
+            'error="other_error", error_description="other_error_description"',
         },
       }),
     );

--- a/sdk/requests/__tests__/getUserInfo.test.js
+++ b/sdk/requests/__tests__/getUserInfo.test.js
@@ -197,7 +197,7 @@ describe('getUserInfo', () => {
       Promise.reject({
         headers: {
           'Www-Authenticate':
-            'error="other_error", error_description="The access token provided is expired, revoked, malformed, or invalid for other reasons"',
+            'error="other_error", error_description="other_error_description"',
         },
       }),
     );


### PR DESCRIPTION
## Descripción

Se cambió la descripción de un error, que debería hacer referencia a "otro tipo de error" (no controlado) y quedó por copy paste que la descripción era invalid token, lo cual confunde.

## Tests
  - [x] Cambios en los tests de integración e unitarios de userInfo

