### PR TITLE
Bugfix/erase state inconsistency

### DIFF
--- a/sdk/__tests__/interfaces-integration/login.test.js
+++ b/sdk/__tests__/interfaces-integration/login.test.js
@@ -816,7 +816,6 @@ describe('configuration & security modules and login integration', () => {
     }
 
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
-    expect(mockLinkingOpenUrl).toHaveBeenCalledWith(correctLoginEndpoint);
     parameters = getParameters();
     expect(parameters).toStrictEqual({
       redirectUri,
@@ -829,14 +828,13 @@ describe('configuration & security modules and login integration', () => {
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      state: mockState,
+      state: '',
       scope: '',
     });
-    expect.assertions(5);
+    expect.assertions(4);
   });
 
   it('calls initialize with clientId different from RP and then calls login', async () => {
-    const badLoginEndpoint = `https://auth-testing.iduruguay.gub.uy/oidc/v1/authorize?scope=openid%20&response_type=code&client_id=invalidClientId&redirect_uri=redirectUri&state=${mockState}`;
     const redirectUri = 'redirectUri';
     const clientId = 'invalidClientId';
     const clientSecret = 'clientSecret';
@@ -866,7 +864,6 @@ describe('configuration & security modules and login integration', () => {
       expect(error).toBe(ERRORS.INVALID_AUTHORIZATION_CODE);
     }
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
-    expect(mockLinkingOpenUrl).toHaveBeenCalledWith(badLoginEndpoint);
     parameters = getParameters();
     expect(parameters).toStrictEqual({
       redirectUri,
@@ -879,14 +876,13 @@ describe('configuration & security modules and login integration', () => {
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      state: mockState,
+      state: '',
       scope: '',
     });
-    expect.assertions(5);
+    expect.assertions(4);
   });
 
   it('calls initialize with redirectUri different from RP and then calls login', async () => {
-    const badLoginEndpoint = `https://auth-testing.iduruguay.gub.uy/oidc/v1/authorize?scope=openid%20&response_type=code&client_id=clientId&redirect_uri=invalidRedirectUri&state=${mockState}`;
     const redirectUri = 'invalidRedirectUri';
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
@@ -916,7 +912,6 @@ describe('configuration & security modules and login integration', () => {
       expect(error).toBe(ERRORS.INVALID_AUTHORIZATION_CODE);
     }
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
-    expect(mockLinkingOpenUrl).toHaveBeenCalledWith(badLoginEndpoint);
     parameters = getParameters();
     expect(parameters).toStrictEqual({
       redirectUri,
@@ -929,10 +924,10 @@ describe('configuration & security modules and login integration', () => {
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      state: mockState,
+      state: '',
       scope: '',
     });
-    expect.assertions(5);
+    expect.assertions(4);
   });
 
   it('calls initialize and login, the user denies access to the application ', async () => {
@@ -970,7 +965,6 @@ describe('configuration & security modules and login integration', () => {
       expect(error).toBe(ERRORS.ACCESS_DENIED);
     }
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
-    expect(mockLinkingOpenUrl).toHaveBeenCalledWith(correctLoginEndpoint);
     parameters = getParameters();
     expect(parameters).toStrictEqual({
       redirectUri,
@@ -983,10 +977,10 @@ describe('configuration & security modules and login integration', () => {
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      state: mockState,
+      state: '',
       scope: '',
     });
-    expect.assertions(5);
+    expect.assertions(4);
   });
 
   it('calls initialize and login with correct parameters, Linking.openUrl fails', async () => {
@@ -1033,8 +1027,7 @@ describe('configuration & security modules and login integration', () => {
       scope: '',
     });
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
-    expect(mockLinkingOpenUrl).toHaveBeenCalledWith(correctLoginEndpoint);
-    expect.assertions(5);
+    expect.assertions(4);
   });
 
   it('calls initialize and login with correct parameters, fetch returns invalid authorization code', async () => {

--- a/sdk/__tests__/interfaces-integration/logout.test.js
+++ b/sdk/__tests__/interfaces-integration/logout.test.js
@@ -347,7 +347,7 @@ describe('configuration & security modules and logout integration', () => {
       tokenType: '',
       expiresIn: '',
       idToken,
-      state: mockState,
+      state: '',
       scope: '',
     });
     expect.assertions(5);
@@ -401,7 +401,7 @@ describe('configuration & security modules and logout integration', () => {
       tokenType: '',
       expiresIn: '',
       idToken,
-      state: mockState,
+      state: '',
       scope: '',
     });
     expect.assertions(5);
@@ -458,7 +458,7 @@ describe('configuration & security modules and logout integration', () => {
       tokenType: '',
       expiresIn: '',
       idToken,
-      state: mockState,
+      state: '',
       scope: '',
     });
     expect.assertions(5);
@@ -511,7 +511,7 @@ describe('configuration & security modules and logout integration', () => {
       tokenType: '',
       expiresIn: '',
       idToken,
-      state: mockState,
+      state: '',
       scope: '',
     });
     expect.assertions(5);

--- a/sdk/__tests__/requests-integration/login.test.js
+++ b/sdk/__tests__/requests-integration/login.test.js
@@ -817,7 +817,6 @@ describe('configuration & security modules and make request type login integrati
     }
 
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
-    expect(mockLinkingOpenUrl).toHaveBeenCalledWith(correctLoginEndpoint);
     parameters = getParameters();
     expect(parameters).toStrictEqual({
       redirectUri,
@@ -830,14 +829,13 @@ describe('configuration & security modules and make request type login integrati
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      state: mockState,
+      state: '',
       scope: '',
     });
-    expect.assertions(5);
+    expect.assertions(4);
   });
 
   it('calls initialize with clientId different from RP and then calls login', async () => {
-    const badLoginEndpoint = `https://auth-testing.iduruguay.gub.uy/oidc/v1/authorize?scope=openid%20&response_type=code&client_id=invalidClientId&redirect_uri=redirectUri&state=${mockState}`;
     const redirectUri = 'redirectUri';
     const clientId = 'invalidClientId';
     const clientSecret = 'clientSecret';
@@ -867,7 +865,6 @@ describe('configuration & security modules and make request type login integrati
       expect(error).toBe(ERRORS.INVALID_AUTHORIZATION_CODE);
     }
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
-    expect(mockLinkingOpenUrl).toHaveBeenCalledWith(badLoginEndpoint);
     parameters = getParameters();
     expect(parameters).toStrictEqual({
       redirectUri,
@@ -880,14 +877,13 @@ describe('configuration & security modules and make request type login integrati
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      state: mockState,
+      state: '',
       scope: '',
     });
-    expect.assertions(5);
+    expect.assertions(4);
   });
 
   it('calls initialize with redirectUri different from RP and then calls login', async () => {
-    const badLoginEndpoint = `https://auth-testing.iduruguay.gub.uy/oidc/v1/authorize?scope=openid%20&response_type=code&client_id=clientId&redirect_uri=invalidRedirectUri&state=${mockState}`;
     const redirectUri = 'invalidRedirectUri';
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
@@ -917,7 +913,6 @@ describe('configuration & security modules and make request type login integrati
       expect(error).toBe(ERRORS.INVALID_AUTHORIZATION_CODE);
     }
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
-    expect(mockLinkingOpenUrl).toHaveBeenCalledWith(badLoginEndpoint);
     parameters = getParameters();
     expect(parameters).toStrictEqual({
       redirectUri,
@@ -930,10 +925,10 @@ describe('configuration & security modules and make request type login integrati
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      state: mockState,
+      state: '',
       scope: '',
     });
-    expect.assertions(5);
+    expect.assertions(4);
   });
 
   it('calls initialize and makes a login request, the user denies access to the application ', async () => {
@@ -971,7 +966,6 @@ describe('configuration & security modules and make request type login integrati
       expect(error).toBe(ERRORS.ACCESS_DENIED);
     }
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
-    expect(mockLinkingOpenUrl).toHaveBeenCalledWith(correctLoginEndpoint);
     parameters = getParameters();
     expect(parameters).toStrictEqual({
       redirectUri,
@@ -984,10 +978,10 @@ describe('configuration & security modules and make request type login integrati
       tokenType: '',
       expiresIn: '',
       idToken: '',
-      state: mockState,
+      state: '',
       scope: '',
     });
-    expect.assertions(5);
+    expect.assertions(4);
   });
 
   it('calls initialize and makes a login request with correct parameters, Linking.openUrl fails', async () => {
@@ -1034,8 +1028,7 @@ describe('configuration & security modules and make request type login integrati
       scope: '',
     });
     expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
-    expect(mockLinkingOpenUrl).toHaveBeenCalledWith(correctLoginEndpoint);
-    expect.assertions(5);
+    expect.assertions(4);
   });
 
   it('calls initialize and makes a login request with correct parameters, fetch returns invalid authorization code', async () => {

--- a/sdk/__tests__/requests-integration/logout.test.js
+++ b/sdk/__tests__/requests-integration/logout.test.js
@@ -348,7 +348,7 @@ describe('configuration & security modules and make request type logout integrat
       tokenType: '',
       expiresIn: '',
       idToken,
-      state: mockState,
+      state: '',
       scope: '',
     });
     expect.assertions(5);
@@ -402,7 +402,7 @@ describe('configuration & security modules and make request type logout integrat
       tokenType: '',
       expiresIn: '',
       idToken,
-      state: mockState,
+      state: '',
       scope: '',
     });
     expect.assertions(5);
@@ -459,7 +459,7 @@ describe('configuration & security modules and make request type logout integrat
       tokenType: '',
       expiresIn: '',
       idToken,
-      state: mockState,
+      state: '',
       scope: '',
     });
     expect.assertions(5);
@@ -512,7 +512,7 @@ describe('configuration & security modules and make request type logout integrat
       tokenType: '',
       expiresIn: '',
       idToken,
-      state: mockState,
+      state: '',
       scope: '',
     });
     expect.assertions(5);

--- a/sdk/requests/login.js
+++ b/sdk/requests/login.js
@@ -42,10 +42,13 @@ const login = async () => {
       });
     } else if (event.url && event.url.indexOf('error=access_denied') !== -1) {
       // Cuando el usuario niega el acceso.
+      eraseState();
       rejectFunction(ERRORS.ACCESS_DENIED);
     } else if (returnedState && returnedState[1] !== parameters.state) {
+      eraseState();
       rejectFunction(ERRORS.INVALID_STATE);
     } else {
+      eraseState();
       rejectFunction(ERRORS.INVALID_AUTHORIZATION_CODE);
     }
 

--- a/sdk/requests/logout.js
+++ b/sdk/requests/logout.js
@@ -46,13 +46,16 @@ const logout = async () => {
       }
       // Si la url contenida en la respuesta no coincide con el
       // logoutEnpoint, se rechaza la promesa retornando un error.
+      eraseState();
       return Promise.reject(ERRORS.INVALID_URL_LOGOUT);
     }
     // En cualquier otro caso, se rechaza la promesa
+    eraseState();
     return Promise.reject(ERRORS.FAILED_REQUEST);
   } catch (error) {
     // En caso de que el estado de la respuesta no sea 200,
     // se rechaza la promesa retornando un error.
+    eraseState();
     return Promise.reject(ERRORS.FAILED_REQUEST);
   }
 };


### PR DESCRIPTION
# Erase state when promise is rejected in login and logout

## Descripción

Se elimina el parámetro state del módulo de configuración cuando ocurre un error en la funcionalidad de login o logout.

## Tests

  - [x] Se modificaron los tests de integración de la request de tipo login para adaptarse a los nuevos cambios.
  - [x] Se modificaron los tests de integración de la request de tipo logout para adaptarse a los nuevos cambios.
  - [x] Se modificaron los tests de integración de la función login para adaptarse a los nuevos cambios.
  - [x] Se modificaron los tests de integración de la función logout para adaptarse a los nuevos cambios.