### PR TITLE
Fix invalid token return

### DIFF
--- a/sdk/__tests__/interfaces-integration/validateToken.test.js
+++ b/sdk/__tests__/interfaces-integration/validateToken.test.js
@@ -790,7 +790,7 @@ describe('configuration & security modules and validate token integration', () =
     try {
       await validateToken();
     } catch (error) {
-      expect(error).toBe(ERRORS.FAILED_REQUEST);
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN);
       expect(KJUR.jws.JWS.verifyJWT).not.toHaveBeenCalled();
     }
     parameters = getParameters();
@@ -853,7 +853,7 @@ describe('configuration & security modules and validate token integration', () =
     try {
       await validateToken();
     } catch (error) {
-      expect(error).toBe(ERRORS.FAILED_REQUEST);
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN);
       expect(KJUR.jws.JWS.verifyJWT).not.toHaveBeenCalled();
     }
 

--- a/sdk/__tests__/requests-integration/validateToken.test.js
+++ b/sdk/__tests__/requests-integration/validateToken.test.js
@@ -792,7 +792,7 @@ describe('configuration & security modules and make request type validate token 
     try {
       await makeRequest(REQUEST_TYPES.VALIDATE_TOKEN);
     } catch (error) {
-      expect(error).toBe(ERRORS.FAILED_REQUEST);
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN);
       expect(KJUR.jws.JWS.verifyJWT).not.toHaveBeenCalled();
     }
     parameters = getParameters();
@@ -855,7 +855,7 @@ describe('configuration & security modules and make request type validate token 
     try {
       await makeRequest(REQUEST_TYPES.VALIDATE_TOKEN);
     } catch (error) {
-      expect(error).toBe(ERRORS.FAILED_REQUEST);
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN);
       expect(KJUR.jws.JWS.verifyJWT).not.toHaveBeenCalled();
     }
 

--- a/sdk/security/__tests__/validateTokenSecurity.test.js
+++ b/sdk/security/__tests__/validateTokenSecurity.test.js
@@ -124,33 +124,6 @@ describe('validateToken', () => {
     expect.assertions(2);
   });
 
-  it('not validates token (alg, iss, aud, expiration)', async () => {
-    base64ToHex.mockImplementation(() => {});
-    base64URLtoBase64.mockReturnValue(() => {});
-
-    KJUR.jws.JWS.verifyJWT.mockImplementation(() => false);
-    KJUR.jws.JWS.readSafeJSONString.mockImplementation(() => ({ kid }));
-    KJUR.jws.JWS.readSafeJSONString.mockImplementationOnce(() => ({
-      acr,
-      amr,
-    }));
-    KJUR.jws.IntDate.getNow.mockImplementation(() => time);
-    KEYUTIL.getKey.mockImplementation(() => pubKey);
-
-    try {
-      await validateTokenSecurity(jwksResponse, idToken, clientId, issuer());
-    } catch (error) {
-      expect(KJUR.jws.JWS.verifyJWT).toHaveBeenCalledWith(idToken, pubKey, {
-        alg: [jwksResponse.keys[0].alg],
-        iss: [issuer()],
-        aud: [clientId],
-        verifyAt: time,
-      });
-      expect(error).toStrictEqual(ERRORS.INVALID_ID_TOKEN);
-    }
-    expect.assertions(2);
-  });
-
   it('not validates token (acr)', async () => {
     base64ToHex.mockImplementation(() => {});
     base64URLtoBase64.mockReturnValue(() => {});

--- a/sdk/security/__tests__/validateTokenSecurity.test.js
+++ b/sdk/security/__tests__/validateTokenSecurity.test.js
@@ -72,6 +72,31 @@ describe('validateToken', () => {
     });
   });
 
+  it('not validates token readSafeJSONString not works', async () => {
+    base64ToHex.mockImplementation(() => {});
+    base64URLtoBase64.mockReturnValue(() => {});
+
+    KJUR.jws.JWS.verifyJWT.mockImplementation(() => false);
+    KJUR.jws.JWS.readSafeJSONString.mockImplementation(() => {
+      throw new Error();
+    });
+    KJUR.jws.IntDate.getNow.mockImplementation(() => time);
+    KEYUTIL.getKey.mockImplementation(() => pubKey);
+
+    try {
+      await validateTokenSecurity(jwksResponse, idToken, clientId, issuer());
+    } catch (error) {
+      expect(KJUR.jws.JWS.verifyJWT).toHaveBeenCalledWith(idToken, pubKey, {
+        alg: [jwksResponse.keys[0].alg],
+        iss: [issuer()],
+        aud: [clientId],
+        verifyAt: time,
+      });
+      expect(error).toStrictEqual(ERRORS.INVALID_ID_TOKEN);
+    }
+    expect.assertions(2);
+  });
+
   it('not validates token (alg, iss, aud, expiration)', async () => {
     base64ToHex.mockImplementation(() => {});
     base64URLtoBase64.mockReturnValue(() => {});

--- a/sdk/security/__tests__/validateTokenSecurity.test.js
+++ b/sdk/security/__tests__/validateTokenSecurity.test.js
@@ -72,7 +72,7 @@ describe('validateToken', () => {
     });
   });
 
-  it('not validates token readSafeJSONString not works', async () => {
+  it('does not validate token when readSafeJSONString throws error', async () => {
     base64ToHex.mockImplementation(() => {});
     base64URLtoBase64.mockReturnValue(() => {});
 

--- a/sdk/security/__tests__/validateTokenSecurity.test.js
+++ b/sdk/security/__tests__/validateTokenSecurity.test.js
@@ -124,6 +124,33 @@ describe('validateToken', () => {
     expect.assertions(2);
   });
 
+  it('not validates token (alg, iss, aud, expiration)', async () => {
+    base64ToHex.mockImplementation(() => {});
+    base64URLtoBase64.mockReturnValue(() => {});
+
+    KJUR.jws.JWS.verifyJWT.mockImplementation(() => false);
+    KJUR.jws.JWS.readSafeJSONString.mockImplementation(() => ({ kid }));
+    KJUR.jws.JWS.readSafeJSONString.mockImplementationOnce(() => ({
+      acr,
+      amr,
+    }));
+    KJUR.jws.IntDate.getNow.mockImplementation(() => time);
+    KEYUTIL.getKey.mockImplementation(() => pubKey);
+
+    try {
+      await validateTokenSecurity(jwksResponse, idToken, clientId, issuer());
+    } catch (error) {
+      expect(KJUR.jws.JWS.verifyJWT).toHaveBeenCalledWith(idToken, pubKey, {
+        alg: [jwksResponse.keys[0].alg],
+        iss: [issuer()],
+        aud: [clientId],
+        verifyAt: time,
+      });
+      expect(error).toStrictEqual(ERRORS.INVALID_ID_TOKEN);
+    }
+    expect.assertions(2);
+  });
+
   it('not validates token (acr)', async () => {
     base64ToHex.mockImplementation(() => {});
     base64URLtoBase64.mockReturnValue(() => {});

--- a/sdk/security/validateTokenSecurity.js
+++ b/sdk/security/validateTokenSecurity.js
@@ -7,26 +7,27 @@ import { base64ToHex, base64URLtoBase64 } from '../utils/encoding';
 
 const validateTokenSecurity = (jwksResponse, idToken, clientId, issuer) => {
   // Se construye la clave pública para verificar la firma del token.
-  const pubKey = KEYUTIL.getKey({
-    n: base64ToHex(base64URLtoBase64(jwksResponse.keys[0].n)),
-    e: base64ToHex(jwksResponse.keys[0].e),
-  });
-
-  // Se valida la firma, los campos alg, iss, aud, y que no esté expirado.
-  // alg: algoritmo de la firma.
-  // iss: quién creo y firmó el token.
-  // aud: para quién está destinado el token
-  // verifyAt: Verifica validez comparada con la hora actual.
-  let isValid = KJUR.jws.JWS.verifyJWT(idToken, pubKey, {
-    alg: [jwksResponse.keys[0].alg],
-    iss: [issuer],
-    aud: [clientId],
-    verifyAt: KJUR.jws.IntDate.getNow(),
-  });
-
+  let isValid;
   let headObj;
   let payloadObj;
   try {
+    const pubKey = KEYUTIL.getKey({
+      n: base64ToHex(base64URLtoBase64(jwksResponse.keys[0].n)),
+      e: base64ToHex(jwksResponse.keys[0].e),
+    });
+
+    // Se valida la firma, los campos alg, iss, aud, y que no esté expirado.
+    // alg: algoritmo de la firma.
+    // iss: quién creo y firmó el token.
+    // aud: para quién está destinado el token
+    // verifyAt: Verifica validez comparada con la hora actual.
+    isValid = KJUR.jws.JWS.verifyJWT(idToken, pubKey, {
+      alg: [jwksResponse.keys[0].alg],
+      iss: [issuer],
+      aud: [clientId],
+      verifyAt: KJUR.jws.IntDate.getNow(),
+    });
+
     // Se obtiene el campo head del token.
     headObj = KJUR.jws.JWS.readSafeJSONString(decode(idToken.split('.')[0]));
 

--- a/sdk/security/validateTokenSecurity.js
+++ b/sdk/security/validateTokenSecurity.js
@@ -19,7 +19,7 @@ const validateTokenSecurity = (jwksResponse, idToken, clientId, issuer) => {
     // Se valida la firma, los campos alg, iss, aud, y que no esté expirado.
     // alg: algoritmo de la firma.
     // iss: quién creo y firmó el token.
-    // aud: para quién está destinado el token
+    // aud: para quién está destinado el token.
     // verifyAt: Verifica validez comparada con la hora actual.
     isValid = KJUR.jws.JWS.verifyJWT(idToken, pubKey, {
       alg: [jwksResponse.keys[0].alg],

--- a/sdk/security/validateTokenSecurity.js
+++ b/sdk/security/validateTokenSecurity.js
@@ -24,15 +24,17 @@ const validateTokenSecurity = (jwksResponse, idToken, clientId, issuer) => {
     verifyAt: KJUR.jws.IntDate.getNow(),
   });
 
-  // Se obtiene el campo head del token.
-  const headObj = KJUR.jws.JWS.readSafeJSONString(
-    decode(idToken.split('.')[0]),
-  );
+  let headObj;
+  let payloadObj;
+  try {
+    // Se obtiene el campo head del token.
+    headObj = KJUR.jws.JWS.readSafeJSONString(decode(idToken.split('.')[0]));
 
-  // Se obtiene el campo head del token.
-  const payloadObj = KJUR.jws.JWS.readSafeJSONString(
-    decode(idToken.split('.')[1]),
-  );
+    // Se obtiene el campo head del token.
+    payloadObj = KJUR.jws.JWS.readSafeJSONString(decode(idToken.split('.')[1]));
+  } catch (err) {
+    return Promise.reject(ERRORS.INVALID_ID_TOKEN);
+  }
 
   // Se valida el kid (identificador único) del token.
   isValid = isValid && headObj.kid === jwksResponse.keys[0].kid;

--- a/sdk/security/validateTokenSecurity.js
+++ b/sdk/security/validateTokenSecurity.js
@@ -30,7 +30,7 @@ const validateTokenSecurity = (jwksResponse, idToken, clientId, issuer) => {
     // Se obtiene el campo head del token.
     headObj = KJUR.jws.JWS.readSafeJSONString(decode(idToken.split('.')[0]));
 
-    // Se obtiene el campo head del token.
+    // Se obtiene el campo payload del token.
     payloadObj = KJUR.jws.JWS.readSafeJSONString(decode(idToken.split('.')[1]));
   } catch (err) {
     return Promise.reject(ERRORS.INVALID_ID_TOKEN);


### PR DESCRIPTION
# Fix invalid token return

## Descripción

Se corrige que cuando el decode falla retorna un request failed en lugar de invalid token,

## Tests

  - [x] not validates token readSafeJSONString not works: la función readSafeJSONString  tira una excepción, la cual es atrapada por el catch en validateTokenSecurity y devuelve invalid token.

