### PR TITLE
Bugfix/correccion errores logout

### DIFF
--- a/sdk/__tests__/interfaces-integration/login.test.js
+++ b/sdk/__tests__/interfaces-integration/login.test.js
@@ -788,7 +788,7 @@ describe('configuration & security modules and login integration', () => {
     mockAddEventListener.mockImplementation((eventType, eventHandler) => {
       if (eventType === 'url')
         eventHandler({
-          url: `${parameters.redirectUri}?code=35773ab93b5b4658b81061ce3969efc2&state=invalid_state`,
+          url: `${parameters.redirectUri}?code=35773ab93b5b4658b81061ce3969efc2&state=differentState`,
         });
     });
 

--- a/sdk/__tests__/interfaces-integration/login.test.js
+++ b/sdk/__tests__/interfaces-integration/login.test.js
@@ -764,7 +764,7 @@ describe('configuration & security modules and login integration', () => {
     expect.assertions(6);
   });
 
-  it('calls initialize and login with correct parameters, fetch returns invalid state', async () => {
+  it('calls initialize and login with correct parameters, fetch returns different state', async () => {
     const redirectUri = 'redirectUri';
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
@@ -789,6 +789,59 @@ describe('configuration & security modules and login integration', () => {
       if (eventType === 'url')
         eventHandler({
           url: `${parameters.redirectUri}?code=35773ab93b5b4658b81061ce3969efc2&state=invalid_state`,
+        });
+    });
+
+    try {
+      await login();
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_STATE);
+    }
+
+    expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(5);
+  });
+
+  it('calls initialize and login with correct parameters, fetch returns empty state', async () => {
+    const redirectUri = 'redirectUri';
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    initialize(redirectUri, clientId, clientSecret, false);
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      scope: '',
+    });
+
+    mockAddEventListener.mockImplementation((eventType, eventHandler) => {
+      if (eventType === 'url')
+        eventHandler({
+          url: `${parameters.redirectUri}?code=35773ab93b5b4658b81061ce3969efc2&state=`,
         });
     });
 

--- a/sdk/__tests__/interfaces-integration/logout.test.js
+++ b/sdk/__tests__/interfaces-integration/logout.test.js
@@ -410,7 +410,7 @@ describe('configuration & security modules and logout integration', () => {
     expect.assertions(6);
   });
 
-  it('calls set parameters and logout, fetch returns empty idtoken', async () => {
+  it('calls set parameters and logout, fetch returns empty idToken', async () => {
     setParameters({ idToken });
 
     let parameters = getParameters();
@@ -469,7 +469,7 @@ describe('configuration & security modules and logout integration', () => {
     expect.assertions(6);
   });
 
-  it('calls set parameters and logout, fetch returns different id token', async () => {
+  it('calls set parameters and logout, fetch returns different idToken', async () => {
     setParameters({ idToken });
 
     let parameters = getParameters();
@@ -528,7 +528,7 @@ describe('configuration & security modules and logout integration', () => {
     expect.assertions(6);
   });
 
-  it('calls set parameters and logout, fetch returns invalid url with id token and state', async () => {
+  it('calls set parameters and logout, fetch returns invalid url with idToken and state', async () => {
     setParameters({ idToken });
 
     let parameters = getParameters();
@@ -585,7 +585,7 @@ describe('configuration & security modules and logout integration', () => {
     expect.assertions(6);
   });
 
-  it('calls set parameters and logout, fetch returns invalid url without id token and state', async () => {
+  it('calls set parameters and logout, fetch returns invalid url without idToken and state', async () => {
     setParameters({ idToken });
 
     let parameters = getParameters();

--- a/sdk/__tests__/interfaces-integration/logout.test.js
+++ b/sdk/__tests__/interfaces-integration/logout.test.js
@@ -320,7 +320,7 @@ describe('configuration & security modules and logout integration', () => {
     try {
       await logout();
     } catch (error) {
-      expect(error).toBe(ERRORS.INVALID_URL_LOGOUT);
+      expect(error).toBe(ERRORS.INVALID_STATE);
     }
 
     expect(fetch).toHaveBeenCalledTimes(1);

--- a/sdk/__tests__/interfaces-integration/logout.test.js
+++ b/sdk/__tests__/interfaces-integration/logout.test.js
@@ -490,7 +490,7 @@ describe('configuration & security modules and logout integration', () => {
     fetch.mockImplementation(() =>
       Promise.resolve({
         status: 200,
-        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=differentState&post_logout_redirect_uri=&state=${mockState}`,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=differentIdToken&post_logout_redirect_uri=&state=${mockState}`,
       }),
     );
 
@@ -603,7 +603,7 @@ describe('configuration & security modules and logout integration', () => {
       scope: '',
     });
     fetch.mockImplementation(() =>
-      Promise.resolve({ status: 200, url: `InvalidUrl` }),
+      Promise.resolve({ status: 200, url: 'InvalidUrl' }),
     );
 
     try {

--- a/sdk/__tests__/interfaces-integration/logout.test.js
+++ b/sdk/__tests__/interfaces-integration/logout.test.js
@@ -320,7 +320,7 @@ describe('configuration & security modules and logout integration', () => {
     try {
       await logout();
     } catch (error) {
-      expect(error).toBe(ERRORS.INVALID_STATE);
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN_HINT);
     }
 
     expect(fetch).toHaveBeenCalledTimes(1);

--- a/sdk/__tests__/interfaces-integration/logout.test.js
+++ b/sdk/__tests__/interfaces-integration/logout.test.js
@@ -320,6 +320,124 @@ describe('configuration & security modules and logout integration', () => {
     try {
       await logout();
     } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_STATE);
+    }
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(6);
+  });
+
+  it('calls set parameters and logout, fetch returns different state', async () => {
+    setParameters({ idToken });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=${idToken}&post_logout_redirect_uri=&state=differentState`,
+      }),
+    );
+
+    try {
+      await logout();
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_STATE);
+    }
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(6);
+  });
+
+  it('calls set parameters and logout, fetch returns empty idtoken', async () => {
+    setParameters({ idToken });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=&post_logout_redirect_uri=&state=${mockState}`,
+      }),
+    );
+
+    try {
+      await logout();
+    } catch (error) {
       expect(error).toBe(ERRORS.INVALID_ID_TOKEN_HINT);
     }
 
@@ -351,7 +469,66 @@ describe('configuration & security modules and logout integration', () => {
     expect.assertions(6);
   });
 
-  it('calls set parameters and logout, fetch returns invalid url', async () => {
+  it('calls set parameters and logout, fetch returns different id token', async () => {
+    setParameters({ idToken });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=differentState&post_logout_redirect_uri=&state=${mockState}`,
+      }),
+    );
+
+    try {
+      await logout();
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN_HINT);
+    }
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(6);
+  });
+
+  it('calls set parameters and logout, fetch returns invalid url with id token and state', async () => {
     setParameters({ idToken });
 
     let parameters = getParameters();
@@ -369,7 +546,64 @@ describe('configuration & security modules and logout integration', () => {
       scope: '',
     });
     fetch.mockImplementation(() =>
-      Promise.resolve({ status: 200, url: 'InvalidUrl' }),
+      Promise.resolve({
+        status: 200,
+        url: `InvalidUrl?id_token_hint=${idToken}&post_logout_redirect_uri=&state=${mockState}`,
+      }),
+    );
+
+    try {
+      await logout();
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_URL_LOGOUT);
+    }
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(6);
+  });
+
+  it('calls set parameters and logout, fetch returns invalid url without id token and state', async () => {
+    setParameters({ idToken });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    fetch.mockImplementation(() =>
+      Promise.resolve({ status: 200, url: `InvalidUrl` }),
     );
 
     try {

--- a/sdk/__tests__/requests-integration/login.test.js
+++ b/sdk/__tests__/requests-integration/login.test.js
@@ -789,7 +789,7 @@ describe('configuration & security modules and make request type login integrati
     mockAddEventListener.mockImplementation((eventType, eventHandler) => {
       if (eventType === 'url')
         eventHandler({
-          url: `${parameters.redirectUri}?code=35773ab93b5b4658b81061ce3969efc2&state=invalid_state`,
+          url: `${parameters.redirectUri}?code=35773ab93b5b4658b81061ce3969efc2&state=differentState`,
         });
     });
 

--- a/sdk/__tests__/requests-integration/login.test.js
+++ b/sdk/__tests__/requests-integration/login.test.js
@@ -765,7 +765,7 @@ describe('configuration & security modules and make request type login integrati
     expect.assertions(6);
   });
 
-  it('calls initialize and makes a login request with correct parameters, fetch returns invalid state', async () => {
+  it('calls initialize and makes a login request with correct parameters, fetch returns different state', async () => {
     const redirectUri = 'redirectUri';
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
@@ -790,6 +790,59 @@ describe('configuration & security modules and make request type login integrati
       if (eventType === 'url')
         eventHandler({
           url: `${parameters.redirectUri}?code=35773ab93b5b4658b81061ce3969efc2&state=invalid_state`,
+        });
+    });
+
+    try {
+      await makeRequest(REQUEST_TYPES.LOGIN);
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_STATE);
+    }
+
+    expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(5);
+  });
+
+  it('calls initialize and makes a login request with correct parameters, fetch returns empty state', async () => {
+    const redirectUri = 'redirectUri';
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    initialize(redirectUri, clientId, clientSecret, false);
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken: '',
+      scope: '',
+    });
+
+    mockAddEventListener.mockImplementation((eventType, eventHandler) => {
+      if (eventType === 'url')
+        eventHandler({
+          url: `${parameters.redirectUri}?code=35773ab93b5b4658b81061ce3969efc2&state=`,
         });
     });
 

--- a/sdk/__tests__/requests-integration/logout.test.js
+++ b/sdk/__tests__/requests-integration/logout.test.js
@@ -411,7 +411,7 @@ describe('configuration & security modules and make request type logout integrat
     expect.assertions(6);
   });
 
-  it('calls set parameters and logout, fetch returns empty idtoken', async () => {
+  it('calls set parameters and logout, fetch returns empty idToken', async () => {
     setParameters({ idToken });
 
     let parameters = getParameters();
@@ -470,7 +470,7 @@ describe('configuration & security modules and make request type logout integrat
     expect.assertions(6);
   });
 
-  it('calls set parameters and logout, fetch returns different id token', async () => {
+  it('calls set parameters and logout, fetch returns different idToken', async () => {
     setParameters({ idToken });
 
     let parameters = getParameters();
@@ -529,7 +529,7 @@ describe('configuration & security modules and make request type logout integrat
     expect.assertions(6);
   });
 
-  it('calls set parameters and makes a logout request, fetch returns invalid url with id token and state', async () => {
+  it('calls set parameters and makes a logout request, fetch returns invalid url with idToken and state', async () => {
     setParameters({ idToken });
 
     let parameters = getParameters();
@@ -586,7 +586,7 @@ describe('configuration & security modules and make request type logout integrat
     expect.assertions(6);
   });
 
-  it('calls set parameters and makes a logout request, fetch returns invalid url without id token and state', async () => {
+  it('calls set parameters and makes a logout request, fetch returns invalid url without idToken and state', async () => {
     setParameters({ idToken });
 
     let parameters = getParameters();

--- a/sdk/__tests__/requests-integration/logout.test.js
+++ b/sdk/__tests__/requests-integration/logout.test.js
@@ -321,7 +321,7 @@ describe('configuration & security modules and make request type logout integrat
     try {
       await makeRequest(REQUEST_TYPES.LOGOUT);
     } catch (error) {
-      expect(error).toBe(ERRORS.INVALID_URL_LOGOUT);
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN_HINT);
     }
 
     expect(fetch).toHaveBeenCalledTimes(1);

--- a/sdk/__tests__/requests-integration/logout.test.js
+++ b/sdk/__tests__/requests-integration/logout.test.js
@@ -321,6 +321,124 @@ describe('configuration & security modules and make request type logout integrat
     try {
       await makeRequest(REQUEST_TYPES.LOGOUT);
     } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_STATE);
+    }
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(6);
+  });
+
+  it('calls set parameters and logout, fetch returns different state', async () => {
+    setParameters({ idToken });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=${idToken}&post_logout_redirect_uri=&state=differentState`,
+      }),
+    );
+
+    try {
+      await makeRequest(REQUEST_TYPES.LOGOUT);
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_STATE);
+    }
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(6);
+  });
+
+  it('calls set parameters and logout, fetch returns empty idtoken', async () => {
+    setParameters({ idToken });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=&post_logout_redirect_uri=&state=${mockState}`,
+      }),
+    );
+
+    try {
+      await makeRequest(REQUEST_TYPES.LOGOUT);
+    } catch (error) {
       expect(error).toBe(ERRORS.INVALID_ID_TOKEN_HINT);
     }
 
@@ -352,7 +470,66 @@ describe('configuration & security modules and make request type logout integrat
     expect.assertions(6);
   });
 
-  it('calls set parameters and makes a logout request, fetch returns invalid url', async () => {
+  it('calls set parameters and logout, fetch returns different id token', async () => {
+    setParameters({ idToken });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=differentState&post_logout_redirect_uri=&state=${mockState}`,
+      }),
+    );
+
+    try {
+      await makeRequest(REQUEST_TYPES.LOGOUT);
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN_HINT);
+    }
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(6);
+  });
+
+  it('calls set parameters and makes a logout request, fetch returns invalid url with id token and state', async () => {
     setParameters({ idToken });
 
     let parameters = getParameters();
@@ -370,7 +547,64 @@ describe('configuration & security modules and make request type logout integrat
       scope: '',
     });
     fetch.mockImplementation(() =>
-      Promise.resolve({ status: 200, url: 'InvalidUrl' }),
+      Promise.resolve({
+        status: 200,
+        url: `InvalidUrl?id_token_hint=${idToken}&post_logout_redirect_uri=&state=${mockState}`,
+      }),
+    );
+
+    try {
+      await makeRequest(REQUEST_TYPES.LOGOUT);
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_URL_LOGOUT);
+    }
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(6);
+  });
+
+  it('calls set parameters and makes a logout request, fetch returns invalid url without id token and state', async () => {
+    setParameters({ idToken });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri: '',
+      clientId: '',
+      clientSecret: '',
+      production: false,
+      code: '',
+      accessToken: '',
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    fetch.mockImplementation(() =>
+      Promise.resolve({ status: 200, url: `InvalidUrl` }),
     );
 
     try {

--- a/sdk/__tests__/requests-integration/logout.test.js
+++ b/sdk/__tests__/requests-integration/logout.test.js
@@ -491,7 +491,7 @@ describe('configuration & security modules and make request type logout integrat
     fetch.mockImplementation(() =>
       Promise.resolve({
         status: 200,
-        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=differentState&post_logout_redirect_uri=&state=${mockState}`,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=differentIdToken&post_logout_redirect_uri=&state=${mockState}`,
       }),
     );
 
@@ -604,7 +604,7 @@ describe('configuration & security modules and make request type logout integrat
       scope: '',
     });
     fetch.mockImplementation(() =>
-      Promise.resolve({ status: 200, url: `InvalidUrl` }),
+      Promise.resolve({ status: 200, url: 'InvalidUrl' }),
     );
 
     try {

--- a/sdk/requests/__tests__/login.test.js
+++ b/sdk/requests/__tests__/login.test.js
@@ -149,7 +149,7 @@ describe('login', () => {
     expect.assertions(3);
   });
 
-  it('calls login with correct clientId, correct redirectUri and return invalid state', async () => {
+  it('calls login with correct clientId, correct redirectUri and return different state', async () => {
     getParameters.mockReturnValue({
       clientId: 'clientId',
       redirectUri: 'redirectUri',
@@ -161,6 +161,30 @@ describe('login', () => {
         eventHandler({
           url:
             'redirectUri?code=35773ab93b5b4658b81061ce3969efc2&state=invalid_state',
+        });
+    });
+    try {
+      await login();
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_STATE);
+    }
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect(mockLinkingOpenUrl).toHaveBeenCalledTimes(1);
+    expect(mockLinkingOpenUrl).toHaveBeenCalledWith(correctLoginEndpoint);
+    expect.assertions(4);
+  });
+
+  it('calls login with correct clientId, correct redirectUri and return empty state', async () => {
+    getParameters.mockReturnValue({
+      clientId: 'clientId',
+      redirectUri: 'redirectUri',
+      clientSecret: 'clientSecret',
+      scope: 'correctScope',
+    });
+    mockAddEventListener.mockImplementation((eventType, eventHandler) => {
+      if (eventType === 'url')
+        eventHandler({
+          url: 'redirectUri?code=35773ab93b5b4658b81061ce3969efc2&state=',
         });
     });
     try {

--- a/sdk/requests/__tests__/login.test.js
+++ b/sdk/requests/__tests__/login.test.js
@@ -160,7 +160,7 @@ describe('login', () => {
       if (eventType === 'url')
         eventHandler({
           url:
-            'redirectUri?code=35773ab93b5b4658b81061ce3969efc2&state=invalid_state',
+            'redirectUri?code=35773ab93b5b4658b81061ce3969efc2&state=differentState',
         });
     });
     try {

--- a/sdk/requests/__tests__/logout.test.js
+++ b/sdk/requests/__tests__/logout.test.js
@@ -80,7 +80,7 @@ describe('logout', () => {
     try {
       await logout();
     } catch (error) {
-      expect(error).toBe(ERRORS.FAILED_REQUEST);
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN_HINT);
     }
     expect(mockMutex).toHaveBeenCalledTimes(1);
   });

--- a/sdk/requests/__tests__/logout.test.js
+++ b/sdk/requests/__tests__/logout.test.js
@@ -85,7 +85,7 @@ describe('logout', () => {
     expect(mockMutex).toHaveBeenCalledTimes(1);
   });
 
-  it('calls logout with required parameters and returns invalid url with id token and state', async () => {
+  it('calls logout with required parameters and fetch returns invalid url with idToken and state', async () => {
     getParameters.mockReturnValue({ idToken, production: false });
     fetch.mockImplementation(() =>
       Promise.resolve({
@@ -111,7 +111,7 @@ describe('logout', () => {
     expect.assertions(4);
   });
 
-  it('calls logout with required parameters and returns invalid url without id token and state', async () => {
+  it('calls logout with required parameters and fetch returns invalid url without idToken and state', async () => {
     getParameters.mockReturnValue({ idToken, production: false });
     fetch.mockImplementation(() =>
       Promise.resolve({ status: 200, url: 'InvalidUrl' }),
@@ -134,7 +134,7 @@ describe('logout', () => {
     expect.assertions(4);
   });
 
-  it('calls logout with required parameters and fails', async () => {
+  it('calls logout with required parameters and fetch fails', async () => {
     getParameters.mockReturnValue({ idToken, production: false });
     fetch.mockImplementation(() => Promise.reject());
     try {

--- a/sdk/requests/__tests__/logout.test.js
+++ b/sdk/requests/__tests__/logout.test.js
@@ -80,7 +80,7 @@ describe('logout', () => {
     try {
       await logout();
     } catch (error) {
-      expect(error).toBe(ERRORS.INVALID_ID_TOKEN_HINT);
+      expect(error).toBe(ERRORS.FAILED_REQUEST);
     }
     expect(mockMutex).toHaveBeenCalledTimes(1);
   });

--- a/sdk/requests/__tests__/logout.test.js
+++ b/sdk/requests/__tests__/logout.test.js
@@ -114,7 +114,7 @@ describe('logout', () => {
   it('calls logout with required parameters and returns invalid url without id token and state', async () => {
     getParameters.mockReturnValue({ idToken, production: false });
     fetch.mockImplementation(() =>
-      Promise.resolve({ status: 200, url: `InvalidUrl` }),
+      Promise.resolve({ status: 200, url: 'InvalidUrl' }),
     );
     try {
       await logout();
@@ -238,7 +238,7 @@ describe('logout', () => {
     fetch.mockImplementation(() =>
       Promise.resolve({
         status: 200,
-        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=differentState&post_logout_redirect_uri=&state=${mockState}`,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=differentIdToken&post_logout_redirect_uri=&state=${mockState}`,
       }),
     );
     try {

--- a/sdk/requests/__tests__/logout.test.js
+++ b/sdk/requests/__tests__/logout.test.js
@@ -85,10 +85,36 @@ describe('logout', () => {
     expect(mockMutex).toHaveBeenCalledTimes(1);
   });
 
-  it('calls logout with required parameters and returns invalid url', async () => {
+  it('calls logout with required parameters and returns invalid url with id token and state', async () => {
     getParameters.mockReturnValue({ idToken, production: false });
     fetch.mockImplementation(() =>
-      Promise.resolve({ status: 200, url: 'badUrl' }),
+      Promise.resolve({
+        status: 200,
+        url: `InvalidUrl?id_token_hint=${idToken}&post_logout_redirect_uri=&state=${mockState}`,
+      }),
+    );
+    try {
+      await logout();
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_URL_LOGOUT);
+    }
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint1, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(4);
+  });
+
+  it('calls logout with required parameters and returns invalid url without id token and state', async () => {
+    getParameters.mockReturnValue({ idToken, production: false });
+    fetch.mockImplementation(() =>
+      Promise.resolve({ status: 200, url: `InvalidUrl` }),
     );
     try {
       await logout();
@@ -115,6 +141,110 @@ describe('logout', () => {
       await logout();
     } catch (error) {
       expect(error).toBe(ERRORS.FAILED_REQUEST);
+    }
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint1, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(4);
+  });
+
+  it('calls logout with required parameters and fetch returns empty state', async () => {
+    getParameters.mockReturnValue({ idToken, production: false });
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=${idToken}&post_logout_redirect_uri=&state=`,
+      }),
+    );
+    try {
+      await logout();
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_STATE);
+    }
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint1, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(4);
+  });
+
+  it('calls logout with required parameters and fetch returns different state', async () => {
+    getParameters.mockReturnValue({ idToken, production: false });
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=${idToken}&post_logout_redirect_uri=&state=differentState`,
+      }),
+    );
+    try {
+      await logout();
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_STATE);
+    }
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint1, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(4);
+  });
+
+  it('calls logout with required parameters and fetch returns empty id token', async () => {
+    getParameters.mockReturnValue({ idToken, production: false });
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=&post_logout_redirect_uri=&state=${mockState}`,
+      }),
+    );
+    try {
+      await logout();
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN_HINT);
+    }
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint1, {
+      method: 'GET',
+      pkPinning: Platform.OS === 'ios',
+      disableAllSecurity: false,
+      sslPinning: {
+        certs: ['certificate'],
+      },
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(4);
+  });
+
+  it('calls logout with required parameters and fetch returns different state', async () => {
+    getParameters.mockReturnValue({ idToken, production: false });
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        url: `https://auth-testing.iduruguay.gub.uy/oidc/v1/logout?id_token_hint=differentState&post_logout_redirect_uri=&state=${mockState}`,
+      }),
+    );
+    try {
+      await logout();
+    } catch (error) {
+      expect(error).toBe(ERRORS.INVALID_ID_TOKEN_HINT);
     }
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(correctLogoutEndpoint1, {

--- a/sdk/requests/login.js
+++ b/sdk/requests/login.js
@@ -26,7 +26,7 @@ const login = async () => {
     // Obtiene el code y state a partir de la url a la que
     // redirige el browser luego de realizado el login.
     const code = event.url.match(/\?code=([^&]+)/);
-    const returnedState = event.url.match(/&state=([^&]+)/);
+    const returnedState = event.url.match(/&state=([^&]*)/);
 
     // Si existe el código y los states coinciden,
     // se guarda y se resuelve la promise.

--- a/sdk/requests/logout.js
+++ b/sdk/requests/logout.js
@@ -33,8 +33,8 @@ const logout = async () => {
     });
     const { status } = response;
     const urlCheck = response.url;
-    const returnedState = urlCheck.match(/&state=([^&]+)/);
-    const returnedIdTokenHint = urlCheck.match(/\?id_token_hint=([^&]+)/);
+    const returnedState = urlCheck.match(/&state=([^&]*)/);
+    const returnedIdTokenHint = urlCheck.match(/\?id_token_hint=([^&]*)/);
 
     // Si los parámetros obligatorios para la request se encuentran
     // inicializados, se procede a evaluar la respuesta del OP.
@@ -51,10 +51,10 @@ const logout = async () => {
       // Si la url contenida en la respuesta no coincide con el
       // logoutEndpoint, se rechaza la promesa retornando un error.
       // Si no coinciden por el state, se retorna el error correspondiente.
-      if (returnedState && returnedState[1] !== state)
+      if (returnedState && (returnedState[1] !== state))
         return Promise.reject(ERRORS.INVALID_STATE);
       // Si no coinciden por el id token, se retorna el error correspondiente.
-      if (returnedIdTokenHint && returnedIdTokenHint !== parameters.idToken)
+      if (returnedIdTokenHint && (returnedIdTokenHint[1] !== parameters.idToken))
         return Promise.reject(ERRORS.INVALID_ID_TOKEN_HINT);
       // En cualquier otro caso se retorna invalid_url
       return Promise.reject(ERRORS.INVALID_URL_LOGOUT);

--- a/sdk/requests/logout.js
+++ b/sdk/requests/logout.js
@@ -51,10 +51,10 @@ const logout = async () => {
       // Si la url contenida en la respuesta no coincide con el
       // logoutEndpoint, se rechaza la promesa retornando un error.
       // Si no coinciden por el state, se retorna el error correspondiente.
-      if (returnedState && (returnedState[1] !== state))
+      if (returnedState && returnedState[1] !== state)
         return Promise.reject(ERRORS.INVALID_STATE);
       // Si no coinciden por el id token, se retorna el error correspondiente.
-      if (returnedIdTokenHint && (returnedIdTokenHint[1] !== parameters.idToken))
+      if (returnedIdTokenHint && returnedIdTokenHint[1] !== parameters.idToken)
         return Promise.reject(ERRORS.INVALID_ID_TOKEN_HINT);
       // En cualquier otro caso se retorna invalid_url
       return Promise.reject(ERRORS.INVALID_URL_LOGOUT);


### PR DESCRIPTION
## Descripción

En logout ahora se retorna invalid state cuando el state retornado es distinto al enviado, lo mismo con id token. En el caso de login se cambió la regex de manera que si se obtiene un state vacío (state=) también se retorne invalid state.

## Tests
  - [x] Todos los tests de logout fueron cambiados para que pasen.
  - [x] Se agregaron tests en logout para los casos de diferente state y vacio, de diferente id token y vacio, de url invalida con state e id token, y url invalida (sin state y sin id token). 
   - [x] Se agrego un test en login para el state vacio 


