### PR TITLE
Fix header error for invalid token ios

### DIFF
--- a/sdk/__tests__/interfaces-integration/getUserInfo.test.js
+++ b/sdk/__tests__/interfaces-integration/getUserInfo.test.js
@@ -767,7 +767,7 @@ describe('configuration & security modules and get user info integration', () =>
     expect.assertions(5);
   });
 
-  it('calls set parameters and get user info with expired accessToken', async () => {
+  it('calls set parameters and get user info with expired accessToken with WWW authenticate header', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -800,6 +800,68 @@ describe('configuration & security modules and get user info integration', () =>
       Promise.reject({
         headers: {
           'WWW-Authenticate':
+            'error="invalid_token", error_description="The access token provided is expired, revoked, malformed, or invalid for other reasons"',
+        },
+      }),
+    );
+
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toStrictEqual(ERRORS.INVALID_TOKEN);
+    }
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(4);
+  });
+
+  it('calls set parameters and get user info with expired accessToken with Www authenticate header', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken,
+      code,
+      redirectUri,
+      idToken,
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.reject({
+        headers: {
+          'Www-Authenticate':
             'error="invalid_token", error_description="The access token provided is expired, revoked, malformed, or invalid for other reasons"',
         },
       }),
@@ -945,7 +1007,7 @@ describe('configuration & security modules and get user info integration', () =>
     expect.assertions(4);
   });
 
-  it('calls set parameters and get user info, fetch returns some error with www authenticate header', async () => {
+  it('calls set parameters and get user info, fetch returns some error with WWW authenticate header', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -977,6 +1039,65 @@ describe('configuration & security modules and get user info integration', () =>
       Promise.reject({
         headers: {
           'WWW-Authenticate':
+            'error="other_error", error_description="other_error_description"',
+        },
+      }),
+    );
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toBe(ERRORS.FAILED_REQUEST);
+    }
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(4);
+  });
+
+  it('calls set parameters and get user info, fetch returns some error with Www authenticate header', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken,
+      code,
+      redirectUri,
+      idToken,
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    fetch.mockImplementation(() =>
+      Promise.reject({
+        headers: {
+          'Www-Authenticate':
             'error="other_error", error_description="other_error_description"',
         },
       }),

--- a/sdk/__tests__/requests-integration/getUserInfo.test.js
+++ b/sdk/__tests__/requests-integration/getUserInfo.test.js
@@ -768,7 +768,7 @@ describe('configuration & security modules and make request type get user info i
     expect.assertions(5);
   });
 
-  it('calls set parameters and makes a get user info request with expired accessToken', async () => {
+  it('calls set parameters and makes a get user info request with expired accessToken with WWW authenticate header', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -801,6 +801,68 @@ describe('configuration & security modules and make request type get user info i
       Promise.reject({
         headers: {
           'WWW-Authenticate':
+            'error="invalid_token", error_description="The access token provided is expired, revoked, malformed, or invalid for other reasons"',
+        },
+      }),
+    );
+
+    try {
+      await makeRequest(REQUEST_TYPES.GET_USER_INFO);
+    } catch (err) {
+      expect(err).toStrictEqual(ERRORS.INVALID_TOKEN);
+    }
+
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(4);
+  });
+
+  it('calls set parameters and makes a get user info request with expired accessToken with Www authenticate header', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken,
+      code,
+      redirectUri,
+      idToken,
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.reject({
+        headers: {
+          'Www-Authenticate':
             'error="invalid_token", error_description="The access token provided is expired, revoked, malformed, or invalid for other reasons"',
         },
       }),
@@ -946,7 +1008,7 @@ describe('configuration & security modules and make request type get user info i
     expect.assertions(4);
   });
 
-  it('calls set parameters and makes a get user info request, fetch returns some error with www authenticate header', async () => {
+  it('calls set parameters and makes a get user info request, fetch returns some error with WWW authenticate header', async () => {
     const clientId = 'clientId';
     const clientSecret = 'clientSecret';
     const code = 'correctCode';
@@ -978,6 +1040,65 @@ describe('configuration & security modules and make request type get user info i
       Promise.reject({
         headers: {
           'WWW-Authenticate':
+            'error="other_error", error_description="other_error_description"',
+        },
+      }),
+    );
+    try {
+      await makeRequest(REQUEST_TYPES.GET_USER_INFO);
+    } catch (err) {
+      expect(err).toBe(ERRORS.FAILED_REQUEST);
+    }
+    parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(4);
+  });
+
+  it('calls set parameters and makes a get user info request, fetch returns some error with Www authenticate header', async () => {
+    const clientId = 'clientId';
+    const clientSecret = 'clientSecret';
+    const code = 'correctCode';
+    const redirectUri = 'redirectUri';
+    setParameters({
+      clientId,
+      clientSecret,
+      accessToken,
+      code,
+      redirectUri,
+      idToken,
+    });
+
+    let parameters = getParameters();
+    expect(parameters).toStrictEqual({
+      redirectUri,
+      clientId,
+      clientSecret,
+      production: false,
+      code,
+      accessToken,
+      refreshToken: '',
+      tokenType: '',
+      expiresIn: '',
+      idToken,
+      scope: '',
+    });
+    fetch.mockImplementation(() =>
+      Promise.reject({
+        headers: {
+          'Www-Authenticate':
             'error="other_error", error_description="other_error_description"',
         },
       }),

--- a/sdk/requests/__tests__/getUserInfo.test.js
+++ b/sdk/requests/__tests__/getUserInfo.test.js
@@ -100,7 +100,7 @@ describe('getUserInfo', () => {
     });
   });
 
-  it('calls getUserInfo with incorrect access token', async () => {
+  it('calls getUserInfo with incorrect access token with WWW authenticate header', async () => {
     getParameters.mockReturnValue({
       clientId: 'clientId',
       clientSecret: 'clientSecret',
@@ -113,6 +113,34 @@ describe('getUserInfo', () => {
       Promise.reject({
         headers: {
           'WWW-Authenticate':
+            'error="invalid_token", error_description="The access token provided is expired, revoked, malformed, or invalid for other reasons"',
+        },
+      }),
+    );
+
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toStrictEqual(ERRORS.INVALID_TOKEN);
+    }
+
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect.assertions(2);
+  });
+
+  it('calls getUserInfo with incorrect access token with Www authenticate header', async () => {
+    getParameters.mockReturnValue({
+      clientId: 'clientId',
+      clientSecret: 'clientSecret',
+      redirectUri: 'redirectUri',
+      accessToken: 'incorrectAccessToken',
+      idToken,
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.reject({
+        headers: {
+          'Www-Authenticate':
             'error="invalid_token", error_description="The access token provided is expired, revoked, malformed, or invalid for other reasons"',
         },
       }),
@@ -198,7 +226,7 @@ describe('getUserInfo', () => {
     expect.assertions(3);
   });
 
-  it('calls getUserInfo and returns some error with www authenticate header', async () => {
+  it('calls getUserInfo and returns some error with WWW authenticate header', async () => {
     getParameters.mockReturnValue({
       clientId: 'clientId',
       clientSecret: 'clientSecret',
@@ -211,6 +239,35 @@ describe('getUserInfo', () => {
       Promise.reject({
         headers: {
           'WWW-Authenticate':
+            'error="other_error", error_description="other_error_description"',
+        },
+      }),
+    );
+
+    try {
+      await getUserInfo();
+    } catch (err) {
+      expect(err).toStrictEqual(ERRORS.FAILED_REQUEST);
+    }
+
+    expect(mockMutex).toHaveBeenCalledTimes(1);
+    expect(validateSub).not.toHaveBeenCalled();
+    expect.assertions(3);
+  });
+
+  it('calls getUserInfo and returns some error with Www authenticate header', async () => {
+    getParameters.mockReturnValue({
+      clientId: 'clientId',
+      clientSecret: 'clientSecret',
+      redirectUri: 'redirectUri',
+      accessToken: 'correctAccessToken',
+      idToken,
+    });
+
+    fetch.mockImplementation(() =>
+      Promise.reject({
+        headers: {
+          'Www-Authenticate':
             'error="other_error", error_description="other_error_description"',
         },
       }),

--- a/sdk/requests/getUserInfo.js
+++ b/sdk/requests/getUserInfo.js
@@ -62,7 +62,13 @@ const getUserInfo = async () => {
     if (error === ERRORS.INVALID_ID_TOKEN) {
       return Promise.reject(ERRORS.INVALID_ID_TOKEN);
     }
-    const stringsHeaders = error.headers && error.headers['WWW-Authenticate'];
+    // const stringsHeadersAndroid =
+    //   error.headers && error.headers['WWW-Authenticate'];
+    // const stringsHeadersIos =
+    //   error.headers && error.headers['Www-Authenticate'];
+    const stringsHeaders =
+      error.headers &&
+      (error.headers['WWW-Authenticate'] || error.headers['Www-Authenticate']);
     if (stringsHeaders && stringsHeaders.indexOf('invalid_token') !== -1)
       return Promise.reject(ERRORS.INVALID_TOKEN);
     return Promise.reject(ERRORS.FAILED_REQUEST);

--- a/sdk/requests/getUserInfo.js
+++ b/sdk/requests/getUserInfo.js
@@ -62,10 +62,6 @@ const getUserInfo = async () => {
     if (error === ERRORS.INVALID_ID_TOKEN) {
       return Promise.reject(ERRORS.INVALID_ID_TOKEN);
     }
-    // const stringsHeadersAndroid =
-    //   error.headers && error.headers['WWW-Authenticate'];
-    // const stringsHeadersIos =
-    //   error.headers && error.headers['Www-Authenticate'];
     const stringsHeaders =
       error.headers &&
       (error.headers['WWW-Authenticate'] || error.headers['Www-Authenticate']);


### PR DESCRIPTION
## Descripción

Al utilizar un access token inválido para obtener la información del usuario en Android se retornaba un error adecuado (indicando que el token era inválido), pero en IOS se retornaba un error indicando una falla en la _request_. Ahora se retorna el error adecuado en IOS. Este error se debía a que los errores venían en cabezales distintos según el sistema operativo, en un cabezal "_WWW-Authenticate_" para Android, y en un cabezal "_Www-Authenticate_" para IOS, pero solo se controlaba el caso de Android.

## Tests
Se agregó un caso con el cabezal de IOS para todas las pruebas que obtenían la información de usuario.


